### PR TITLE
style: format the log for module of paper,user and launch_screen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/nyaruka/phonenumbers v1.4.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/crypt v0.26.0 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect

--- a/internal/launch_screen/handler.go
+++ b/internal/launch_screen/handler.go
@@ -44,7 +44,7 @@ func (s *LaunchScreenServiceImpl) CreateImage(stream launch_screen.LaunchScreenS
 	// 首先取得除文件外的其他字段
 	req, err := stream.Recv()
 	if err != nil {
-		logger.Infof("LaunchScreen.CreateImage recv request: %v", err)
+		logger.Errorf("LaunchScreen.CreateImage recv request: %+v", err)
 		resp.Base = base.BuildBaseResp(err)
 		return stream.SendAndClose(resp)
 	}
@@ -53,7 +53,7 @@ func (s *LaunchScreenServiceImpl) CreateImage(stream launch_screen.LaunchScreenS
 	for i := 0; i < int(req.BufferCount); i++ {
 		fileReq, err := stream.Recv()
 		if err != nil {
-			logger.Infof("LaunchScreen.CreateImage recv file: %v", err)
+			logger.Errorf("LaunchScreen.CreateImage recv file: %+v", err)
 			resp.Base = base.BuildBaseResp(err)
 			return stream.SendAndClose(resp)
 		}
@@ -62,7 +62,7 @@ func (s *LaunchScreenServiceImpl) CreateImage(stream launch_screen.LaunchScreenS
 
 	pic, err := service.NewLaunchScreenService(stream.Context(), s.ClientSet).CreateImage(req)
 	if err != nil {
-		logger.Infof("LaunchScreen.CreateImage: %v", err)
+		logger.Errorf("LaunchScreen.CreateImage: %+v", err)
 		resp.Base = base.BuildBaseResp(err)
 		return stream.SendAndClose(resp)
 	}
@@ -80,7 +80,7 @@ func (s *LaunchScreenServiceImpl) GetImage(ctx context.Context, req *launch_scre
 	pic, err := service.NewLaunchScreenService(ctx, s.ClientSet).GetImageById(req.PictureId)
 	resp.Base = base.BuildBaseResp(err)
 	if err != nil {
-		logger.Infof("LaunchScreen.GetImage: %v", err)
+		logger.Errorf("LaunchScreen.GetImage: %+v", err)
 		return resp, nil
 	}
 	resp.Picture = pack.BuildImageResp(pic)
@@ -95,7 +95,7 @@ func (s *LaunchScreenServiceImpl) ChangeImageProperty(ctx context.Context,
 	pic, err := service.NewLaunchScreenService(ctx, s.ClientSet).UpdateImageProperty(req)
 	resp.Base = base.BuildBaseResp(err)
 	if err != nil {
-		logger.Infof("LaunchScreen.ChangeImageProperty: %v", err)
+		logger.Errorf("LaunchScreen.ChangeImageProperty: %+v", err)
 		return resp, nil
 	}
 	resp.Picture = pack.BuildImageResp(pic)
@@ -108,7 +108,7 @@ func (s *LaunchScreenServiceImpl) ChangeImage(stream launch_screen.LaunchScreenS
 	// 首先取得除文件外的其他字段
 	req, err := stream.Recv()
 	if err != nil {
-		logger.Infof("LaunchScreen.ChangeImage recv request: %v", err)
+		logger.Errorf("LaunchScreen.ChangeImage recv request: %+v", err)
 		resp.Base = base.BuildBaseResp(err)
 		return stream.SendAndClose(resp)
 	}
@@ -117,7 +117,7 @@ func (s *LaunchScreenServiceImpl) ChangeImage(stream launch_screen.LaunchScreenS
 	for i := 0; i < int(req.BufferCount); i++ {
 		fileReq, err := stream.Recv()
 		if err != nil {
-			logger.Infof("LaunchScreen.ChangeImage recv file: %v", err)
+			logger.Errorf("LaunchScreen.ChangeImage recv file: %+v", err)
 			resp.Base = base.BuildBaseResp(err)
 			return stream.SendAndClose(resp)
 		}
@@ -125,7 +125,7 @@ func (s *LaunchScreenServiceImpl) ChangeImage(stream launch_screen.LaunchScreenS
 	}
 	pic, err := service.NewLaunchScreenService(stream.Context(), s.ClientSet).UpdateImagePath(req)
 	if err != nil {
-		logger.Infof("LaunchScreen.ChangeImage: %v", err)
+		logger.Errorf("LaunchScreen.ChangeImage: %+v", err)
 		resp.Base = base.BuildBaseResp(err)
 		return stream.SendAndClose(resp)
 	}
@@ -141,7 +141,7 @@ func (s *LaunchScreenServiceImpl) DeleteImage(ctx context.Context, req *launch_s
 	err = service.NewLaunchScreenService(ctx, s.ClientSet).DeleteImage(req.PictureId)
 	if err != nil {
 		resp.Base = base.BuildBaseResp(err)
-		logger.Infof("LaunchScreen.DeleteImage: %v", err)
+		logger.Errorf("LaunchScreen.DeleteImage: %+v", err)
 		return resp, nil
 	}
 
@@ -158,7 +158,7 @@ func (s *LaunchScreenServiceImpl) MobileGetImage(ctx context.Context, req *launc
 	pictureList, cnt, err := service.NewLaunchScreenService(ctx, s.ClientSet).MobileGetImage(req)
 	if err != nil {
 		resp.Base = base.BuildBaseResp(err)
-		logger.Infof("LaunchScreen.MobileGetImage: %v", err)
+		logger.Errorf("LaunchScreen.MobileGetImage: %+v", err)
 		return resp, nil
 	}
 
@@ -176,7 +176,7 @@ func (s *LaunchScreenServiceImpl) AddImagePointTime(ctx context.Context, req *la
 	err = service.NewLaunchScreenService(ctx, s.ClientSet).AddPointTime(req.PictureId)
 	resp.Base = base.BuildBaseResp(err)
 	if err != nil {
-		logger.Infof("LaunchScreen.AddImagePointTime: %v", err)
+		logger.Errorf("LaunchScreen.AddImagePointTime: %+v", err)
 	}
 	return resp, nil
 }

--- a/internal/launch_screen/service/create_image.go
+++ b/internal/launch_screen/service/create_image.go
@@ -17,9 +17,9 @@ limitations under the License.
 package service
 
 import (
-	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/west2-online/fzuhelper-server/kitex_gen/launch_screen"
@@ -67,7 +67,7 @@ func (s *LaunchScreenService) CreateImage(req *launch_screen.CreateImageRequest)
 		return upyun.UploadImg(req.Image, imgUrl)
 	})
 	if err = eg.Wait(); err != nil {
-		return nil, fmt.Errorf("LaunchScreenService.CreateImage error:%w", err)
+		return nil, errors.Errorf("LaunchScreen.CreateImage SFCreateIDError: %v", err)
 	}
 	return pic, nil
 }

--- a/internal/launch_screen/service/delete_image.go
+++ b/internal/launch_screen/service/delete_image.go
@@ -17,7 +17,7 @@ limitations under the License.
 package service
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/west2-online/fzuhelper-server/pkg/upyun"
 )
@@ -25,10 +25,10 @@ import (
 func (s *LaunchScreenService) DeleteImage(id int64) error {
 	pic, err := s.db.LaunchScreen.DeleteImage(s.ctx, id)
 	if err != nil {
-		return fmt.Errorf("LaunchScreenService.DeleteImage error:%w", err)
+		return errors.Errorf("LaunchScreenService.DeleteImage error: %v", err)
 	}
 	if err = upyun.DeleteImg(pic.Url); err != nil {
-		return fmt.Errorf("LaunchScreen.DeleteImage error: %w", err)
+		return errors.Errorf("LaunchScreen.DeleteImage error: %v", err)
 	}
 	return nil
 }

--- a/internal/launch_screen/service/get_image.go
+++ b/internal/launch_screen/service/get_image.go
@@ -17,7 +17,7 @@ limitations under the License.
 package service
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/west2-online/fzuhelper-server/pkg/db/model"
 )
@@ -25,7 +25,7 @@ import (
 func (s *LaunchScreenService) GetImageById(id int64) (*model.Picture, error) {
 	img, err := s.db.LaunchScreen.GetImageById(s.ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("LaunchScreenService.GetImageById error:%w", err)
+		return nil, errors.Errorf("LaunchScreenService.GetImageById error: %v", err)
 	}
 	return img, nil
 }

--- a/internal/launch_screen/service/point_time.go
+++ b/internal/launch_screen/service/point_time.go
@@ -17,13 +17,13 @@ limitations under the License.
 package service
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 )
 
 func (s *LaunchScreenService) AddPointTime(id int64) error {
 	err := s.db.LaunchScreen.AddPointTime(s.ctx, id)
 	if err != nil {
-		return fmt.Errorf("LaunchScreenService.AddPointTime err: %w", err)
+		return errors.Errorf("LaunchScreenService.AddPointTime err: %v", err)
 	}
 	return nil
 }

--- a/internal/launch_screen/service/update_image.go
+++ b/internal/launch_screen/service/update_image.go
@@ -17,8 +17,7 @@ limitations under the License.
 package service
 
 import (
-	"fmt"
-
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/west2-online/fzuhelper-server/kitex_gen/launch_screen"
@@ -30,7 +29,7 @@ import (
 func (s *LaunchScreenService) UpdateImagePath(req *launch_screen.ChangeImageRequest) (pic *model.Picture, err error) {
 	origin, err := s.db.LaunchScreen.GetImageById(s.ctx, req.PictureId)
 	if err != nil {
-		return nil, fmt.Errorf("LaunchScreenService.UpdateImagePath db.GetImageById error: %w", err)
+		return nil, errors.Errorf("LaunchScreenService.UpdateImagePath db.GetImageById error: %v", err)
 	}
 
 	delUrl := origin.Url
@@ -61,7 +60,7 @@ func (s *LaunchScreenService) UpdateImagePath(req *launch_screen.ChangeImageRequ
 		return err2
 	})
 	if err = eg.Wait(); err != nil {
-		return nil, fmt.Errorf("LaunchScreenService.UpdateImagePath error: %w", err)
+		return nil, errors.Errorf("LaunchScreenService.UpdateImagePath error: %v", err)
 	}
 	return pic, nil
 }

--- a/internal/launch_screen/service/update_image_property.go
+++ b/internal/launch_screen/service/update_image_property.go
@@ -17,8 +17,9 @@ limitations under the License.
 package service
 
 import (
-	"fmt"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/west2-online/fzuhelper-server/kitex_gen/launch_screen"
 	"github.com/west2-online/fzuhelper-server/pkg/db/model"
@@ -27,7 +28,7 @@ import (
 func (s *LaunchScreenService) UpdateImageProperty(req *launch_screen.ChangeImagePropertyRequest) (*model.Picture, error) {
 	origin, err := s.db.LaunchScreen.GetImageById(s.ctx, req.PictureId)
 	if err != nil {
-		return nil, fmt.Errorf("LaunchScreenService.UpdateImageProperty error: %w", err)
+		return nil, errors.Errorf("LaunchScreenService.UpdateImageProperty error: %v", err)
 	}
 	origin.PicType = req.PicType
 	origin.SType = req.SType
@@ -42,7 +43,7 @@ func (s *LaunchScreenService) UpdateImageProperty(req *launch_screen.ChangeImage
 	origin.Regex = req.Regex
 	pic, err := s.db.LaunchScreen.UpdateImage(s.ctx, origin)
 	if err != nil {
-		return nil, fmt.Errorf("LaunchScreenService.UpdateImageProperty error: %w", err)
+		return nil, errors.Errorf("LaunchScreenService.UpdateImageProperty error: %v", err)
 	}
 	return pic, nil
 }

--- a/internal/paper/handler.go
+++ b/internal/paper/handler.go
@@ -47,12 +47,12 @@ func (s *PaperServiceImpl) ListDirFiles(ctx context.Context, req *paper.ListDirF
 
 	success, fileDir, err = service.NewPaperService(ctx, s.ClientSet).GetDir(req)
 	if !success {
-		logger.Infof("Paper.ListDirFiles: get dir info failed from upyun")
+		logger.Errorf("Paper.ListDirFiles: get dir info failed from upyun")
 		resp.Base = base.BuildBaseResp(errors.New("failed to get info from upyun"))
 		return resp, nil
 	}
 	if err != nil {
-		logger.Infof("Paper.ListDirFiles: get dir info failed: %v", err)
+		logger.Errorf("Paper.ListDirFiles: get dir info failed: %+v", err)
 		resp.Base = base.BuildBaseResp(errors.New("failed to get info from upyun"))
 		return resp, nil
 	}
@@ -68,7 +68,7 @@ func (s *PaperServiceImpl) GetDownloadUrl(ctx context.Context, req *paper.GetDow
 
 	url, err := service.NewPaperService(ctx, s.ClientSet).GetDownloadUrl(req)
 	if err != nil {
-		logger.Infof("Paper.GetDownloadUrl: get download url failed: %v", err)
+		logger.Errorf("Paper.GetDownloadUrl: get download url failed: %+v", err)
 		resp.Base = base.BuildBaseResp(err)
 		return resp, nil
 	}

--- a/internal/paper/service/get_dir.go
+++ b/internal/paper/service/get_dir.go
@@ -17,7 +17,7 @@ limitations under the License.
 package service
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/west2-online/fzuhelper-server/kitex_gen/model"
 	"github.com/west2-online/fzuhelper-server/kitex_gen/paper"
@@ -40,13 +40,13 @@ func (s *PaperService) GetDir(req *paper.ListDirFilesRequest) (bool, *model.UpYu
 		}
 
 		if err != nil {
-			return false, nil, fmt.Errorf("service.GetDir: get dir info failed: %w", err)
+			return false, nil, errors.Errorf("service.GetDir: get dir info failed: %v", err)
 		}
 	}
 
 	fileDir, err = upyun.GetDir(req.Path)
 	if err != nil {
-		return false, nil, fmt.Errorf("service.GetDir: get dir info failed: %w", err)
+		return false, nil, errors.Errorf("service.GetDir: get dir info failed: %v", err)
 	}
 
 	err = s.cache.Paper.SetFileDirCache(s.ctx, key, *fileDir)

--- a/internal/user/handler.go
+++ b/internal/user/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/west2-online/fzuhelper-server/internal/user/service"
 	"github.com/west2-online/fzuhelper-server/kitex_gen/user"
 	"github.com/west2-online/fzuhelper-server/pkg/base"
+	"github.com/west2-online/fzuhelper-server/pkg/logger"
 )
 
 // UserServiceImpl implements the last service interface defined in the IDL.
@@ -33,6 +34,7 @@ func (s *UserServiceImpl) GetLoginData(ctx context.Context, req *user.GetLoginDa
 	l := service.NewUserService(ctx, "", nil)
 	id, cookies, err := l.GetLoginData(req)
 	if err != nil {
+		logger.Errorf("%+v", err)
 		resp.Base = base.BuildBaseResp(err)
 		return resp, nil
 	}

--- a/internal/user/service/get_logindata.go
+++ b/internal/user/service/get_logindata.go
@@ -17,6 +17,8 @@ limitations under the License.
 package service
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/west2-online/fzuhelper-server/kitex_gen/user"
 	"github.com/west2-online/fzuhelper-server/pkg/utils"
 	"github.com/west2-online/jwch"
@@ -25,7 +27,7 @@ import (
 func (s *UserService) GetLoginData(req *user.GetLoginDataRequest) (string, []string, error) {
 	id, rawCookies, err := jwch.NewStudent().WithUser(req.Id, req.Password).GetIdentifierAndCookies()
 	if err != nil {
-		return "", nil, err
+		return "", nil, errors.Errorf("faield get indentifer and cookies,err: %v", err)
 	}
 	return id, utils.ParseCookiesToString(rawCookies), nil
 }

--- a/pkg/cache/paper/get_file_dir.go
+++ b/pkg/cache/paper/get_file_dir.go
@@ -18,9 +18,9 @@ package paper
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/bytedance/sonic"
+	"github.com/pkg/errors"
 
 	"github.com/west2-online/fzuhelper-server/kitex_gen/model"
 )
@@ -30,11 +30,11 @@ func (c *CachePaper) GetFileDirCache(ctx context.Context, key string) (bool, *mo
 
 	data, err := c.client.Get(ctx, key).Bytes()
 	if err != nil {
-		return false, ret, fmt.Errorf("dal.GetFileDirCache: get dir info failed: %w", err)
+		return false, ret, errors.Errorf("dal.GetFileDirCache: get dir info failed: %v", err)
 	}
 	err = sonic.Unmarshal(data, &ret)
 	if err != nil {
-		return false, ret, fmt.Errorf("dal.GetFileDirCache: Unmarshal dir info failed: %w", err)
+		return false, ret, errors.Errorf("dal.GetFileDirCache: Unmarshal dir info failed: %v", err)
 	}
 	return true, ret, nil
 }

--- a/pkg/upyun/launch_screen.go
+++ b/pkg/upyun/launch_screen.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/west2-online/fzuhelper-server/config"
 	"github.com/west2-online/fzuhelper-server/pkg/errno"
 )
@@ -32,13 +34,13 @@ func UploadImg(file []byte, url string) error {
 	body := bytes.NewReader(file)
 	req, err := http.NewRequest("PUT", url, body)
 	if err != nil {
-		return err
+		return errors.Errorf("faield make new http request,err: %v", err)
 	}
 	req.SetBasicAuth(config.UpYun.Operator, config.UpYun.Password)
 	req.Header.Add("Date", time.Now().UTC().Format(http.TimeFormat))
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return errors.Errorf("failed send http request,err: %v", err)
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
@@ -51,13 +53,13 @@ func UploadImg(file []byte, url string) error {
 func DeleteImg(url string) error {
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
-		return err
+		return errors.Errorf("faield create http request,err: %v", err)
 	}
 	req.SetBasicAuth(config.UpYun.Operator, config.UpYun.Password)
 	req.Header.Add("Date", time.Now().UTC().Format(http.TimeFormat))
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return errors.Errorf("failed send http request,err: %v", err)
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {


### PR DESCRIPTION
该PR主要是针对日志的输出与规范做了一些更改，这其中最终的就是error的更规范(详细)的处理。

针对error来说，我们只需要在error不再被继续传递的时候打印他即可，也就是我们的handler部分，error到此为止了，不会再继续向下传递，也就可以认为是error的终点，所以调用即可。

对于一些包，可能有一些error会发生，但我们并不期望返回他，那我们也可以记录下来这个信息，即便我们不希望他的error影响到我们的程序本身，但我认为对非nil error的记录仍然是有必要的。

对于包的使用，全部选择了`pkg/errors` 这是一个简单但满足我们使用需求的包，也是star最多的。虽然他归档了，但并没有安全性问题，我认为是可以继续使用的。