### PR TITLE
chore: optimize auth error response

### DIFF
--- a/api/mw/token.go
+++ b/api/mw/token.go
@@ -90,10 +90,13 @@ func CreateToken(tokenType int64) (string, error) {
 
 // CheckToken 会检查 token 是否有效，如果有效则返回 token 类型，否则返回错误(type 会返回 -1)
 func CheckToken(token string) (int64, error) {
+	if token == "" {
+		return -1, errno.AuthMissing
+	}
 	// 解析 token，但不进行签名验证
 	tokenStruct, _, err := new(jwt.Parser).ParseUnverified(token, &Claims{})
 	if err != nil {
-		return -1, err
+		return -1, errno.AuthInvalid.WithError(err)
 	}
 
 	unverifiedClaims, ok := tokenStruct.Claims.(*Claims)

--- a/pkg/errno/code.go
+++ b/pkg/errno/code.go
@@ -47,7 +47,6 @@ const (
 	AuthInvalidCode        = 30002 // 鉴权无效
 	AuthAccessExpiredCode  = 30003 // 访问令牌过期
 	AuthRefreshExpiredCode = 30004 // 刷新令牌过期
-	AuthMissingCode        = 30005 // 鉴权缺失
 
 	BizErrorCode               = 40001 // 业务错误
 	BizLogicCode               = 40002 // 业务逻辑错误

--- a/pkg/errno/default.go
+++ b/pkg/errno/default.go
@@ -24,11 +24,11 @@ var (
 	Success                   = NewErrNo(SuccessCode, "ok")
 	CustomLaunchScreenSuccess = NewErrNo(consts.StatusOK, "ok") // 兼容处理
 
-	AuthError          = NewErrNo(AuthErrorCode, "鉴权失败")            // 鉴权失败，通常是内部错误，如解析失败
-	AuthInvalid        = NewErrNo(AuthInvalidCode, "鉴权无效")          // 鉴权无效，如令牌颁发者不是 west2-online
+	AuthError          = NewErrNo(AuthErrorCode, "鉴权失败")              // 鉴权失败，通常是内部错误，如解析失败
+	AuthInvalid        = NewErrNo(AuthInvalidCode, "鉴权无效")            // 鉴权无效，如令牌颁发者不是 west2-online
 	AuthAccessExpired  = NewErrNo(AuthAccessExpiredCode, "访问令牌过期")  // 访问令牌过期
 	AuthRefreshExpired = NewErrNo(AuthRefreshExpiredCode, "刷新令牌过期") // 刷新令牌过期
-	AuthMissing        = NewErrNo(AuthMissingCode, "鉴权缺失")          // 鉴权缺失，如访问令牌缺失
+	AuthMissing        = NewErrNo(AuthInvalidCode, "缺失合法鉴权数据")    // 鉴权缺失，如访问令牌缺失
 
 	ParamError         = NewErrNo(ParamErrorCode, "参数错误") // 参数校验失败，可能是参数为空、参数类型错误等
 	ParamMissingHeader = NewErrNo(ParamMissingHeaderCode, "缺失合法学生请求头数据")


### PR DESCRIPTION
<!--  感谢您提交一个 Pull Request！

-->
#### 自查 PR 结构
<!--
自查通过后在方框中打一个 x 就可以勾选，如果需要访问关于commit 签名的信息，可以访问
https://docs.github.com/zh/authentication/managing-commit-signature-verification/signing-commits

一个可能的标题示例: `[BREAKING CHANGE] feat(core): add new feature`
-->
- [x] PR 标题符合这个格式: \<type\>(optional scope): \<description\>
- [x] 此 PR 标题的描述以用户为导向，足够清晰，其他人可以理解。
- [x] 我已经对所有 commit 提供了签名（GPG 密钥签名、SSH 密钥签名）

- [ ] 这个 PR 属于强制变更/破坏性更改
> 如果是，请在 PR 标题中添加 `BREAKING CHANGE` 前缀，并在 PR 描述中详细说明。

#### 这个 PR 的类型是什么？
<!--
添加以下类型的一种:

build: 影响构建系统或外部依赖项的更改 (常用 scope: gulp, broccoli, npm)
ci: 更改我们的 CI 配置文件和脚本 (常用 scope: Travis, Circle, BrowserStack, SauceLabs)
docs: 只包含文档的更改
feat: 一个新的特性
optimize: 对已有代码的优化
fix: 修正 bug
perf: 对代码的性能提升
refactor: 重构，或代码更改既没有修复错误也没有添加功能
style: 不影响代码含义的更改 (空白行/空格, 格式优化, 缺失的分号, etc.)
test: 添加缺失的测试或更正现有的测试
chore: 构建过程或辅助工具和库（如文档生成）的变更
-->

chore

#### 这个 PR 做了什么 / 我们为什么需要这个 PR？
<!--
对于每次的Code Review，我们都需要一个清晰的 PR 描述，以便 Reviewer 能够理解 PR 的目的。
这是对 Reviewer 一个很好的引导，减轻 Review 的难度和压力，同时便于 PR 更快的通过
-->

当鉴权出现问题（比如内部错误、etc）时，注意到会直接返回原始数据，导致响应码变为 50001（内部服务错误），但实际上应当是鉴权失败（30002），该 pr 修正了这个问题

同时，删去了鉴权缺失（30005），鉴权缺失时同样使用 30002 鉴权失败响应码

#### (可选)这个 PR 解决了哪个/些 issue？
<!--
PR 合并时会自动关闭链接问题
用法: `Fixes #<issue number>`, 或者 `Fixes (粘贴 issue 链接)`.
-->

#### 对 Reviewer 预留的一些提醒
