### PR TITLE
feat: use controlled concurrency kafka consumers instead of goroutines

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -214,31 +214,31 @@ services:
 #    networks:
 #       - fzuhelper
 #
-#  kafka:
-#    container_name: fzuhelper-kafka
-#    image: bitnami/kafka:latest
-#    restart: always
-#    user: root
-#    ports:
-#      - "9092:9092"
-#      - "9093:9093"
-#    env_file:
-#      - ./env/kafka.env
-#    volumes:
-#      - ./data/kafka:/bitnami/kafka
-#    networks:
-#      - fzuhelper
-#
-#  kafka-ui:
-#    container_name: fzuhelper-kafka-ui
-#    image: provectuslabs/kafka-ui:latest
-#    restart: always
-#    ports:
-#      - "9091:8080"
-#    env_file:
-#      - ./env/kafka-ui.env
-#    networks:
-#      - fzuhelper
+  kafka:
+    container_name: fzuhelper-kafka
+    image: bitnami/kafka:latest
+    restart: always
+    user: root
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    env_file:
+      - ./env/kafka.env
+    volumes:
+      - ./data/kafka:/bitnami/kafka
+    networks:
+      - fzuhelper
+
+  kafka-ui:
+    container_name: fzuhelper-kafka-ui
+    image: provectuslabs/kafka-ui:latest
+    restart: always
+    ports:
+      - "9091:8080"
+    env_file:
+      - ./env/kafka-ui.env
+    networks:
+      - fzuhelper
 
 networks:
   fzuhelper:

--- a/internal/academic/handler.go
+++ b/internal/academic/handler.go
@@ -23,18 +23,21 @@ import (
 	"github.com/west2-online/fzuhelper-server/internal/academic/service"
 	"github.com/west2-online/fzuhelper-server/kitex_gen/academic"
 	"github.com/west2-online/fzuhelper-server/pkg/base"
+	"github.com/west2-online/fzuhelper-server/pkg/kafka"
 	"github.com/west2-online/fzuhelper-server/pkg/logger"
 	"github.com/west2-online/jwch"
 )
 
 // AcademicServiceImpl implements the last service interface defined in the IDL.
 type AcademicServiceImpl struct {
-	ClientSet *base.ClientSet
+	ClientSet     *base.ClientSet
+	KafkaInstance *kafka.Kafka
 }
 
-func NewAcademicService(clientSet *base.ClientSet) *AcademicServiceImpl {
+func NewAcademicService(clientSet *base.ClientSet, instance *kafka.Kafka) *AcademicServiceImpl {
 	return &AcademicServiceImpl{
-		ClientSet: clientSet,
+		ClientSet:     clientSet,
+		KafkaInstance: instance,
 	}
 }
 
@@ -43,7 +46,7 @@ func (s *AcademicServiceImpl) GetScores(ctx context.Context, _ *academic.GetScor
 	resp = academic.NewGetScoresResponse()
 	var scores []*jwch.Mark
 
-	scores, err = service.NewAcademicService(ctx, s.ClientSet).GetScores()
+	scores, err = service.NewAcademicService(ctx, s.ClientSet, s.KafkaInstance).GetScores()
 	if err != nil {
 		logger.Infof("Academic.GetScores: GetScores failed, err: %v", err)
 		resp.Base = base.BuildBaseResp(err)
@@ -60,7 +63,7 @@ func (s *AcademicServiceImpl) GetGPA(ctx context.Context, _ *academic.GetGPARequ
 	resp = academic.NewGetGPAResponse()
 	var gpa *jwch.GPABean
 
-	gpa, err = service.NewAcademicService(ctx, s.ClientSet).GetGPA()
+	gpa, err = service.NewAcademicService(ctx, s.ClientSet, nil).GetGPA()
 	if err != nil {
 		logger.Infof("Academic.GetGPA: GetGPA failed, err: %v", err)
 		resp.Base = base.BuildBaseResp(err)
@@ -76,7 +79,7 @@ func (s *AcademicServiceImpl) GetCredit(ctx context.Context, _ *academic.GetCred
 	resp = academic.NewGetCreditResponse()
 	var credit []*jwch.CreditStatistics
 
-	credit, err = service.NewAcademicService(ctx, s.ClientSet).GetCredit()
+	credit, err = service.NewAcademicService(ctx, s.ClientSet, nil).GetCredit()
 	if err != nil {
 		logger.Infof("Academic.GetCredit: GetCredit failed, err: %v", err)
 		resp.Base = base.BuildBaseResp(err)
@@ -93,7 +96,7 @@ func (s *AcademicServiceImpl) GetUnifiedExam(ctx context.Context, _ *academic.Ge
 	resp = academic.NewGetUnifiedExamResponse()
 	var unifiedExam []*jwch.UnifiedExam
 
-	unifiedExam, err = service.NewAcademicService(ctx, s.ClientSet).GetUnifiedExam()
+	unifiedExam, err = service.NewAcademicService(ctx, s.ClientSet, nil).GetUnifiedExam()
 	if err != nil {
 		logger.Infof("Academic.GetUnifiedExam: GetUnifiedExam failed, err: %v", err)
 		resp.Base = base.BuildBaseResp(err)
@@ -108,7 +111,7 @@ func (s *AcademicServiceImpl) GetUnifiedExam(ctx context.Context, _ *academic.Ge
 // GetPlan implements the AcademicServiceImpl interface.
 func (s *AcademicServiceImpl) GetPlan(ctx context.Context, _ *academic.GetPlanRequest) (resp *academic.GetPlanResponse, err error) {
 	resp = new(academic.GetPlanResponse)
-	url, err := service.NewAcademicService(ctx, s.ClientSet).GetPlan()
+	url, err := service.NewAcademicService(ctx, s.ClientSet, nil).GetPlan()
 	if err != nil {
 		resp.Base = base.BuildBaseResp(err)
 		return resp, nil

--- a/internal/academic/kafka/consumer.go
+++ b/internal/academic/kafka/consumer.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 The west2-online Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"context"
+
+	"github.com/bytedance/sonic"
+
+	"github.com/west2-online/fzuhelper-server/pkg/cache"
+	"github.com/west2-online/fzuhelper-server/pkg/constants"
+	"github.com/west2-online/fzuhelper-server/pkg/kafka"
+	"github.com/west2-online/fzuhelper-server/pkg/logger"
+	"github.com/west2-online/fzuhelper-server/pkg/utils"
+)
+
+type AcademicConsumer struct {
+	kafkaInstance *kafka.Kafka
+	cache         *cache.Cache
+}
+
+func InitAcademicConsumer(cache *cache.Cache, instance *kafka.Kafka) *AcademicConsumer {
+	return &AcademicConsumer{
+		kafkaInstance: instance,
+		cache:         cache,
+	}
+}
+
+func (c *AcademicConsumer) Close() {
+	c.kafkaInstance.Close()
+}
+
+func (c *AcademicConsumer) ConsumeMessage(topic string, consumerNum int, groupID string) {
+	consumerCh := c.kafkaInstance.Consume(context.Background(), topic, consumerNum, groupID)
+	for i := 0; i < consumerNum; i++ {
+		go c.handleKafkaMessages(consumerCh)
+	}
+}
+
+func (c *AcademicConsumer) handleKafkaMessages(consumerCh <-chan *kafka.Message) {
+	for kafkaMsg := range consumerCh {
+		key := utils.BytesToInt64(kafkaMsg.K)
+
+		switch key {
+		case constants.AcademicSetScoresCacheEventKey:
+			var payload ScoresCacheMessage
+			err := sonic.Unmarshal(kafkaMsg.V, &payload)
+			if err != nil {
+				logger.Errorf("Kafka consumer: Failed to unmarshal ScoresCache payload: %v", err)
+				continue
+			}
+			c.cache.Academic.SetScoresCache(context.Background(), payload.Key, payload.Scores)
+			logger.Infof("Kafka consumer: ScoresCache updated for key: %d", key)
+
+		default:
+			logger.Warnf("Kafka consumer: Unknown message key: %v", key)
+		}
+	}
+}

--- a/internal/academic/kafka/consumer.go
+++ b/internal/academic/kafka/consumer.go
@@ -64,7 +64,6 @@ func (c *AcademicConsumer) handleKafkaMessages(consumerCh <-chan *kafka.Message)
 				continue
 			}
 			c.cache.Academic.SetScoresCache(context.Background(), payload.Key, payload.Scores)
-			logger.Infof("Kafka consumer: ScoresCache updated for key: %d", key)
 
 		default:
 			logger.Warnf("Kafka consumer: Unknown message key: %v", key)

--- a/internal/academic/kafka/model.go
+++ b/internal/academic/kafka/model.go
@@ -14,30 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package constants
+package kafka
 
-const (
-	KafkaReadMinBytes      = 512 * B
-	KafkaReadMaxBytes      = 1 * MB
-	KafkaRetries           = 3
-	DefaultReaderGroupID   = "r"
-	DefaultTimeRetainHours = 6 // 6小时
+import "github.com/west2-online/jwch"
 
-	DefaultConsumerChanCap        = 20
-	DefaultKafkaProducerSyncWrite = false
-
-	DefaultKafkaNumPartitions     = -1
-	DefaultKafkaReplicationFactor = -1
-)
-
-const (
-	KafkaAcademicCacheConsumerNum = 2
-)
-
-const (
-	KafkaAcademicCacheTopic = "academic-cache"
-)
-
-const (
-	AcademicSetScoresCacheEventKey = iota
-)
+type ScoresCacheMessage struct {
+	Key    string       `json:"key"`
+	Scores []*jwch.Mark `json:"scores"`
+}

--- a/internal/academic/service/get_scores_test.go
+++ b/internal/academic/service/get_scores_test.go
@@ -122,7 +122,7 @@ func TestAcademicService_GetScores(t *testing.T) {
 				Return().
 				Build()
 
-			academicService := NewAcademicService(context.Background(), mockClientSet)
+			academicService := NewAcademicService(context.Background(), mockClientSet, nil)
 			result, err := academicService.GetScores()
 			if tc.expectingError {
 				assert.Nil(t, result)

--- a/internal/academic/service/get_scores_test.go
+++ b/internal/academic/service/get_scores_test.go
@@ -19,7 +19,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/west2-online/fzuhelper-server/pkg/kafka"
 	"testing"
 
 	"github.com/bytedance/mockey"
@@ -30,6 +29,7 @@ import (
 	meta "github.com/west2-online/fzuhelper-server/pkg/base/context"
 	"github.com/west2-online/fzuhelper-server/pkg/cache"
 	academicCache "github.com/west2-online/fzuhelper-server/pkg/cache/academic"
+	"github.com/west2-online/fzuhelper-server/pkg/kafka"
 	"github.com/west2-online/jwch"
 )
 

--- a/internal/academic/service/get_scores_test.go
+++ b/internal/academic/service/get_scores_test.go
@@ -19,6 +19,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"github.com/west2-online/fzuhelper-server/pkg/kafka"
 	"testing"
 
 	"github.com/bytedance/mockey"
@@ -121,7 +122,7 @@ func TestAcademicService_GetScores(t *testing.T) {
 			mockey.Mock((*academicCache.CacheAcademic).SetScoresCache).
 				Return().
 				Build()
-
+			mockey.Mock((*kafka.Kafka).Send).Return(nil).Build()
 			academicService := NewAcademicService(context.Background(), mockClientSet, nil)
 			result, err := academicService.GetScores()
 			if tc.expectingError {

--- a/internal/academic/service/service.go
+++ b/internal/academic/service/service.go
@@ -21,16 +21,19 @@ import (
 
 	"github.com/west2-online/fzuhelper-server/pkg/base"
 	"github.com/west2-online/fzuhelper-server/pkg/cache"
+	"github.com/west2-online/fzuhelper-server/pkg/kafka"
 )
 
 type AcademicService struct {
 	ctx   context.Context
 	cache *cache.Cache
+	kafka *kafka.Kafka
 }
 
-func NewAcademicService(ctx context.Context, clientset *base.ClientSet) *AcademicService {
+func NewAcademicService(ctx context.Context, clientset *base.ClientSet, instance *kafka.Kafka) *AcademicService {
 	return &AcademicService{
 		ctx:   ctx,
 		cache: clientset.CacheClient,
+		kafka: instance,
 	}
 }

--- a/pkg/kafka/kafka.go
+++ b/pkg/kafka/kafka.go
@@ -101,7 +101,7 @@ func (k *Kafka) Send(ctx context.Context, topic string, messages []*Message) []e
 // SetWriter 针对特定的 topic 生成一个并发安全的 writer,
 // SetWriter 会在 topic 不存在的时候创建他
 func (k *Kafka) SetWriter(topic string, asyncWrite ...bool) error {
-	async := constants.DefaultKafkaProductorSyncWrite
+	async := constants.DefaultKafkaProducerSyncWrite
 	if asyncWrite != nil {
 		async = asyncWrite[0]
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package utils
 
 import (
+	"encoding/binary"
 	"errors"
 	"io"
 	"mime/multipart"
@@ -225,4 +226,21 @@ func GetImageFileType(fileBytes *[]byte) (string, error) {
 // GenerateRedisKeyByStuId 开屏页通过学号与sType与device生成缓存对应Key
 func GenerateRedisKeyByStuId(stuId string, sType int64, device string) string {
 	return strings.Join([]string{stuId, device, strconv.FormatInt(sType, 10)}, ":")
+}
+
+const int64Size = 8
+
+// Int64ToBytes int64 转 []byte（大端序）
+func Int64ToBytes(n int64) []byte {
+	b := make([]byte, int64Size)
+	binary.BigEndian.PutUint64(b, uint64(n))
+	return b
+}
+
+// BytesToInt64 []byte 转 int64（大端序）
+func BytesToInt64(b []byte) int64 {
+	if len(b) != int64Size {
+		return -1 // 注意-1为无效的值
+	}
+	return int64(binary.BigEndian.Uint64(b))
 }


### PR DESCRIPTION
<!--  感谢您提交一个 Pull Request！

-->
#### 自查 PR 结构
<!--
自查通过后在方框中打一个 x 就可以勾选，如果需要访问关于commit 签名的信息，可以访问
https://docs.github.com/zh/authentication/managing-commit-signature-verification/signing-commits

一个可能的标题示例: `[BREAKING CHANGE] feat(core): add new feature`
-->
- [x] PR 标题符合这个格式: \<type\>(optional scope): \<description\>
- [x] 此 PR 标题的描述以用户为导向，足够清晰，其他人可以理解。
- [x] 我已经对所有 commit 提供了签名（GPG 密钥签名、SSH 密钥签名）

- [ ] 这个 PR 属于强制变更/破坏性更改
> 如果是，请在 PR 标题中添加 `BREAKING CHANGE` 前缀，并在 PR 描述中详细说明。

#### 这个 PR 的类型是什么？
<!--
添加以下类型的一种:

build: 影响构建系统或外部依赖项的更改 (常用 scope: gulp, broccoli, npm)
ci: 更改我们的 CI 配置文件和脚本 (常用 scope: Travis, Circle, BrowserStack, SauceLabs)
docs: 只包含文档的更改
feat: 一个新的特性
optimize: 对已有代码的优化
fix: 修正 bug
perf: 对代码的性能提升
refactor: 重构，或代码更改既没有修复错误也没有添加功能
style: 不影响代码含义的更改 (空白行/空格, 格式优化, 缺失的分号, etc.)
test: 添加缺失的测试或更正现有的测试
chore: 构建过程或辅助工具和库（如文档生成）的变更
-->

#### 这个 PR 做了什么 / 我们为什么需要这个 PR？
<!--
对于每次的Code Review，我们都需要一个清晰的 PR 描述，以便 Reviewer 能够理解 PR 的目的。
这是对 Reviewer 一个很好的引导，减轻 Review 的难度和压力，同时便于 PR 更快的通过
-->
一个在项目中常见的做法是：缓存未命中 -> 查数据库/爬虫拿数据 -> 开启goroutine写缓存
在高并发的场景下，这样到处开goroutine有可能会造成较大的资源竞争和内存占用，这个pr以获取成绩这个接口为例，将写缓存调用操作抽象成kafka message，交给有限个kafka消费者进行消费处理
#### (可选)这个 PR 解决了哪个/些 issue？
<!--
PR 合并时会自动关闭链接问题
用法: `Fixes #<issue number>`, 或者 `Fixes (粘贴 issue 链接)`.
-->

#### 对 Reviewer 预留的一些提醒
看看设计有没有问题，封装参考了syncer
