### PR TITLE
fix: incorrect stu identifier as key to cache

### DIFF
--- a/internal/academic/service/get_scores.go
+++ b/internal/academic/service/get_scores.go
@@ -22,7 +22,6 @@ import (
 	"github.com/west2-online/fzuhelper-server/internal/academic/task_model"
 	"github.com/west2-online/fzuhelper-server/pkg/base"
 	"github.com/west2-online/fzuhelper-server/pkg/base/context"
-	"github.com/west2-online/fzuhelper-server/pkg/constants"
 	"github.com/west2-online/fzuhelper-server/pkg/utils"
 	"github.com/west2-online/jwch"
 )
@@ -33,7 +32,7 @@ func (s *AcademicService) GetScores() ([]*jwch.Mark, error) {
 		return nil, fmt.Errorf("service.GetScores: Get login data fail %w", err)
 	}
 
-	key := fmt.Sprintf("scores:%s", loginData.Id[len(loginData.Id)-constants.StudentIDLength:])
+	key := fmt.Sprintf("scores:%s", context.ExtractIDFromLoginData(loginData))
 	if ok := s.cache.IsKeyExist(s.ctx, key); ok {
 		scores, err := s.cache.Academic.GetScoresCache(s.ctx, key)
 		if err != nil {
@@ -47,7 +46,7 @@ func (s *AcademicService) GetScores() ([]*jwch.Mark, error) {
 			return nil, fmt.Errorf("service.GetScores: Get scores info fail %w", err)
 		}
 		s.taskQueue.Add(task_model.NewSetScoresCacheTask(key, scores, s.cache, s.ctx))
-		s.taskQueue.Add(task_model.NewPutScoresToDatabaseTask(s.ctx, s.db, loginData.Id, scores))
+		s.taskQueue.Add(task_model.NewPutScoresToDatabaseTask(s.ctx, s.db, context.ExtractIDFromLoginData(loginData), scores))
 		return scores, nil
 	}
 }

--- a/internal/classroom/service/get_exam_room.go
+++ b/internal/classroom/service/get_exam_room.go
@@ -31,7 +31,7 @@ func (s *ClassroomService) GetExamRoomInfo(req *classroom.ExamRoomInfoRequest) (
 	if err != nil {
 		return nil, fmt.Errorf("service.GetExamRoomInfo: Get login data fail %w", err)
 	}
-	key := fmt.Sprintf("exam:user:%s:term:%s", loginData.GetId(), req.GetTerm())
+	key := fmt.Sprintf("exam:user:%s:term:%s", context.ExtractIDFromLoginData(loginData), req.GetTerm())
 
 	if ok := s.cache.IsKeyExist(s.ctx, key); ok {
 		examRooms, err := s.cache.Classroom.GetExamRoom(s.ctx, key)

--- a/internal/course/service/get_calendar.go
+++ b/internal/course/service/get_calendar.go
@@ -83,7 +83,7 @@ func (s *CourseService) GetCalendar(req *course.GetCalendarRequest) (string, err
 	// 转换为 ics 格式
 	cal := ics.NewCalendar()
 	cal.SetMethod(ics.MethodRequest)
-	cal.SetXWRCalName(fmt.Sprintf("福州大学课程表 [%s]", loginData.Id))
+	cal.SetXWRCalName(fmt.Sprintf("福州大学课程表 [%s]", context.ExtractIDFromLoginData(loginData)))
 	cal.SetTimezoneId("Asia/Shanghai")
 	cal.SetXWRTimezone("Asia/Shanghai")
 

--- a/internal/course/service/get_terms.go
+++ b/internal/course/service/get_terms.go
@@ -38,8 +38,8 @@ func (s *CourseService) GetTermsList(req *course.TermListRequest) ([]string, err
 		return nil, fmt.Errorf("service.GetTermList: Get login data fail: %w", err)
 	}
 
-	if s.cache.IsKeyExist(s.ctx, loginData.GetId()) {
-		terms, err := s.cache.Course.GetTermsCache(s.ctx, loginData.GetId())
+	if s.cache.IsKeyExist(s.ctx, context.ExtractIDFromLoginData(loginData)) {
+		terms, err := s.cache.Course.GetTermsCache(s.ctx, context.ExtractIDFromLoginData(loginData))
 		if err = base.HandleJwchError(err); err != nil {
 			return nil, fmt.Errorf("service.GetTermList: Get terms cache fail: %w", err)
 		}
@@ -52,7 +52,7 @@ func (s *CourseService) GetTermsList(req *course.TermListRequest) ([]string, err
 		return nil, fmt.Errorf("service.GetTermList: Get terms fail: %w", err)
 	}
 	go func() {
-		err = s.cache.Course.SetTermsCache(s.ctx, loginData.GetId(), terms.Terms)
+		err = s.cache.Course.SetTermsCache(s.ctx, context.ExtractIDFromLoginData(loginData), terms.Terms)
 		if err = base.HandleJwchError(err); err != nil {
 			logger.Errorf("service.GetTermList: set cache fail: %v", err)
 		}

--- a/internal/user/service/get_logindata.go
+++ b/internal/user/service/get_logindata.go
@@ -22,6 +22,7 @@ import (
 	"github.com/west2-online/jwch"
 )
 
+// GetLoginData 内部测试用登录教务处
 func (s *UserService) GetLoginData(req *user.GetLoginDataRequest) (string, []string, error) {
 	stu := jwch.NewStudent().WithUser(req.Id, req.Password)
 	id, rawCookies, err := stu.GetIdentifierAndCookies()

--- a/pkg/base/context/login_data.go
+++ b/pkg/base/context/login_data.go
@@ -18,6 +18,7 @@ package context
 
 import (
 	"context"
+	"github.com/west2-online/fzuhelper-server/pkg/constants"
 
 	"github.com/bytedance/sonic"
 
@@ -49,4 +50,12 @@ func GetLoginData(ctx context.Context) (*model.LoginData, error) {
 		return nil, errno.InternalServiceError.WithMessage("Failed to get header in context when unmarshalling loginData")
 	}
 	return value, nil
+}
+
+// ExtractIDFromLoginData 从 LoginData 中提取出学号，因为 LoginData 末9位设计为了学号
+func ExtractIDFromLoginData(data *model.LoginData) string {
+	if data.Id == "" || len(data.Id) < constants.StudentIDLength {
+		return ""
+	}
+	return data.Id[len(data.Id)-constants.StudentIDLength:]
 }

--- a/pkg/taskqueue/queue.go
+++ b/pkg/taskqueue/queue.go
@@ -69,7 +69,7 @@ func (btq *BaseTaskQueue) worker() {
 		case QueueTask:
 			if err := task.Execute(); err != nil {
 				btq.workQueue.AddRateLimited(task)
-				logger.Warnf("BaseTaskQueue:task failed: %v", err)
+				logger.Errorf("BaseTaskQueue:task failed: %v", err)
 			} else {
 				btq.workQueue.Done(task)
 			}


### PR DESCRIPTION
<!--  感谢您提交一个 Pull Request！

-->
#### 自查 PR 结构
<!--
自查通过后在方框中打一个 x 就可以勾选，如果需要访问关于commit 签名的信息，可以访问
https://docs.github.com/zh/authentication/managing-commit-signature-verification/signing-commits

一个可能的标题示例: `[BREAKING CHANGE] feat(core): add new feature`
-->
- [x] PR 标题符合这个格式: \<type\>(optional scope): \<description\>
- [x] 此 PR 标题的描述以用户为导向，足够清晰，其他人可以理解。
- [x] 我已经对所有 commit 提供了签名（GPG 密钥签名、SSH 密钥签名）

- [ ] 这个 PR 属于强制变更/破坏性更改
> 如果是，请在 PR 标题中添加 `BREAKING CHANGE` 前缀，并在 PR 描述中详细说明。

#### 这个 PR 的类型是什么？
<!--
添加以下类型的一种:

build: 影响构建系统或外部依赖项的更改 (常用 scope: gulp, broccoli, npm)
ci: 更改我们的 CI 配置文件和脚本 (常用 scope: Travis, Circle, BrowserStack, SauceLabs)
docs: 只包含文档的更改
feat: 一个新的特性
optimize: 对已有代码的优化
fix: 修正 bug
perf: 对代码的性能提升
refactor: 重构，或代码更改既没有修复错误也没有添加功能
style: 不影响代码含义的更改 (空白行/空格, 格式优化, 缺失的分号, etc.)
test: 添加缺失的测试或更正现有的测试
chore: 构建过程或辅助工具和库（如文档生成）的变更
-->

fix

#### 这个 PR 做了什么 / 我们为什么需要这个 PR？
<!--
对于每次的Code Review，我们都需要一个清晰的 PR 描述，以便 Reviewer 能够理解 PR 的目的。
这是对 Reviewer 一个很好的引导，减轻 Review 的难度和压力，同时便于 PR 更快的通过
-->

当前关于 Cache 缓存的 key 设置时往往会使用 `loginData.ID`，但实际上这个 ID 是一种session
我们只能提取其末尾的 9 位数（即学号）来进行缓存。

这里定义了一个新的函数`context.ExtractIDFromLoginData(loginData)`，作为一层封装。

> 需要注意的是，如果长度不够（提取失败），我们会返回一个空文本，思考了一下，作为一个 fallback，没什么问题

#### (可选)这个 PR 解决了哪个/些 issue？
<!--
PR 合并时会自动关闭链接问题
用法: `Fixes #<issue number>`, 或者 `Fixes (粘贴 issue 链接)`.
-->

#### 对 Reviewer 预留的一些提醒
