### PR TITLE
fix: revise db.IsNoticeExists for unique notice

### DIFF
--- a/cmd/common/main.go
+++ b/cmd/common/main.go
@@ -152,7 +152,7 @@ func syncNoticeTask() error {
 	for _, row := range content {
 		// 判断是否已存在
 		ctx := context.Background()
-		ok, err := clientSet.DBClient.Notice.IsNoticeExists(ctx, row.Title)
+		ok, err := clientSet.DBClient.Notice.IsNoticeExists(ctx, row.Title, row.URL)
 		if err != nil {
 			return fmt.Errorf("notice sync task: failed to check url exists: %w", err)
 		}

--- a/pkg/db/notice/is_notice_exists.go
+++ b/pkg/db/notice/is_notice_exists.go
@@ -23,10 +23,10 @@ import (
 	"github.com/west2-online/fzuhelper-server/pkg/errno"
 )
 
-// IsNoticeExists 根据 title 做为唯一索引
-func (d *DBNotice) IsNoticeExists(ctx context.Context, title string) (ok bool, err error) {
+// IsNoticeExists 根据 title 和 url 做为唯一索引
+func (d *DBNotice) IsNoticeExists(ctx context.Context, title string, url string) (ok bool, err error) {
 	var count int64
-	err = d.client.WithContext(ctx).Table(constants.NoticeTableName).Where("title = ?", title).Count(&count).Error
+	err = d.client.WithContext(ctx).Table(constants.NoticeTableName).Where("title = ? AND url = ?", title).Count(&count).Error
 	if err != nil {
 		return false, errno.Errorf(errno.InternalDatabaseErrorCode, "dal.IsTitleExists error: %s", err)
 	}


### PR DESCRIPTION
<!--  感谢您提交一个 Pull Request！

-->
#### 自查 PR 结构
<!--
自查通过后在方框中打一个 x 就可以勾选，如果需要访问关于commit 签名的信息，可以访问
https://docs.github.com/zh/authentication/managing-commit-signature-verification/signing-commits

一个可能的标题示例: `[BREAKING CHANGE] feat(core): add new feature`
-->
- [x] PR 标题符合这个格式: \<type\>(optional scope): \<description\>
- [x] 此 PR 标题的描述以用户为导向，足够清晰，其他人可以理解。
- [x] 我已经对所有 commit 提供了签名（GPG 密钥签名、SSH 密钥签名）

- [ ] 这个 PR 属于强制变更/破坏性更改
> 如果是，请在 PR 标题中添加 `BREAKING CHANGE` 前缀，并在 PR 描述中详细说明。

#### 这个 PR 的类型是什么？
<!--
添加以下类型的一种:

build: 影响构建系统或外部依赖项的更改 (常用 scope: gulp, broccoli, npm)
ci: 更改我们的 CI 配置文件和脚本 (常用 scope: Travis, Circle, BrowserStack, SauceLabs)
docs: 只包含文档的更改
feat: 一个新的特性
optimize: 对已有代码的优化
fix: 修正 bug
perf: 对代码的性能提升
refactor: 重构，或代码更改既没有修复错误也没有添加功能
style: 不影响代码含义的更改 (空白行/空格, 格式优化, 缺失的分号, etc.)
test: 添加缺失的测试或更正现有的测试
chore: 构建过程或辅助工具和库（如文档生成）的变更
-->

#### 这个 PR 做了什么 / 我们为什么需要这个 PR？
<!--
对于每次的Code Review，我们都需要一个清晰的 PR 描述，以便 Reviewer 能够理解 PR 的目的。
这是对 Reviewer 一个很好的引导，减轻 Review 的难度和压力，同时便于 PR 更快的通过
-->
- 数据库层通过 notice 和 url 来判断 notice 的唯一性，但在业务层却只使用了 title来判断，造成有些 title 相同但是 url 不同的通知遗漏
#### (可选)这个 PR 解决了哪个/些 issue？
<!--
PR 合并时会自动关闭链接问题
用法: `Fixes #<issue number>`, 或者 `Fixes (粘贴 issue 链接)`.
-->

#### 对 Reviewer 预留的一些提醒
