### PR TITLE
fix(course): preserve campus prefix for yjsy course locations

### DIFF
--- a/internal/course/pack/course.go
+++ b/internal/course/pack/course.go
@@ -26,21 +26,22 @@ import (
 	"github.com/west2-online/yjsy"
 )
 
-func normalizeCourseLocation(location string) string {
+func normalizeCourseLocation(location string, isGraduate bool) string {
 	if location == "旗山物理实验教学中心" || location == "铜盘教学楼" {
 		return location
 	}
-
-	// 去除 {铜盘,旗山} 前缀
-	location = strings.TrimPrefix(location, "铜盘")
-	location = strings.TrimPrefix(location, "旗山")
+	if !isGraduate {
+		// 非研究生 去除 {铜盘,旗山} 前缀
+		location = strings.TrimPrefix(location, "铜盘")
+		location = strings.TrimPrefix(location, "旗山")
+	}
 
 	return location
 }
 
 func buildScheduleRule(scheduleRule jwch.CourseScheduleRule) *model.CourseScheduleRule {
 	return &model.CourseScheduleRule{
-		Location:   normalizeCourseLocation(scheduleRule.Location),
+		Location:   normalizeCourseLocation(scheduleRule.Location, false),
 		StartClass: int64(scheduleRule.StartClass),
 		EndClass:   int64(scheduleRule.EndClass),
 		StartWeek:  int64(scheduleRule.StartWeek),
@@ -71,7 +72,7 @@ func buildAdjustRule(adjustRule jwch.CourseAdjustRule) *model.CourseAdjustRule {
 		NewDay_:        int64(adjustRule.NewWeekday),
 		NewStartClass_: int64(adjustRule.NewStartClass),
 		NewEndClass_:   int64(adjustRule.NewEndClass),
-		NewLocation_:   normalizeCourseLocation(adjustRule.NewLocation),
+		NewLocation_:   normalizeCourseLocation(adjustRule.NewLocation, false),
 	}
 }
 
@@ -114,7 +115,7 @@ func GetTop2Terms(term *jwch.Term) *jwch.Term {
 
 func buildScheduleRuleYjsy(scheduleRule yjsy.CourseScheduleRule) *model.CourseScheduleRule {
 	return &model.CourseScheduleRule{
-		Location:   normalizeCourseLocation(scheduleRule.Location),
+		Location:   normalizeCourseLocation(scheduleRule.Location, true),
 		StartClass: int64(scheduleRule.StartClass),
 		EndClass:   int64(scheduleRule.EndClass),
 		StartWeek:  int64(scheduleRule.StartWeek),


### PR DESCRIPTION
<!--  感谢您提交一个 Pull Request！

-->
#### 自查 PR 结构
<!--
自查通过后在方框中打一个 x 就可以勾选，如果需要访问关于commit 签名的信息，可以访问
https://docs.github.com/zh/authentication/managing-commit-signature-verification/signing-commits

一个可能的标题示例: `[BREAKING CHANGE] feat(core): add new feature`
-->
- [x] PR 标题符合这个格式: \<type\>(optional scope): \<description\>
- [x] 此 PR 标题的描述以用户为导向，足够清晰，其他人可以理解。
- [x] 我已经对所有 commit 提供了签名（GPG 密钥签名、SSH 密钥签名）

- [ ] 这个 PR 属于强制变更/破坏性更改
> 如果是，请在 PR 标题中添加 `BREAKING CHANGE` 前缀，并在 PR 描述中详细说明。

#### 这个 PR 的类型是什么？
<!--
添加以下类型的一种:

build: 影响构建系统或外部依赖项的更改 (常用 scope: gulp, broccoli, npm)
ci: 更改我们的 CI 配置文件和脚本 (常用 scope: Travis, Circle, BrowserStack, SauceLabs)
docs: 只包含文档的更改
feat: 一个新的特性
optimize: 对已有代码的优化
fix: 修正 bug
perf: 对代码的性能提升
refactor: 重构，或代码更改既没有修复错误也没有添加功能
style: 不影响代码含义的更改 (空白行/空格, 格式优化, 缺失的分号, etc.)
test: 添加缺失的测试或更正现有的测试
chore: 构建过程或辅助工具和库（如文档生成）的变更
-->
fix(course): 保留研究生课表教室的前缀校区信息

#### 这个 PR 做了什么 / 我们为什么需要这个 PR？
<!--
对于每次的Code Review，我们都需要一个清晰的 PR 描述，以便 Reviewer 能够理解 PR 的目的。
这是对 Reviewer 一个很好的引导，减轻 Review 的难度和压力，同时便于 PR 更快的通过
-->
研究生课表的教室信息格式不统一，直接删除校区信息会导致信息错乱

#### (可选)这个 PR 解决了哪个/些 issue？
<!--
PR 合并时会自动关闭链接问题
用法: `Fixes #<issue number>`, 或者 `Fixes (粘贴 issue 链接)`.
-->

#### 对 Reviewer 预留的一些提醒
