### PR TITLE
chore(ci): specify workflow permissions

### DIFF
--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -12,6 +12,9 @@ on:
       - "**"
       - "!**.md"
 
+permissions:
+  contents: read
+
 jobs:
   vulncheck-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/west2-online/fzuhelper-server/security/code-scanning/13](https://github.com/west2-online/fzuhelper-server/security/code-scanning/13)

Add an explicit `permissions` block to the workflow to constrain `GITHUB_TOKEN` to the minimum needed.  
Best fix here (without changing functionality): define workflow-level permissions right after `on:` (or before `jobs:`), setting:

- `contents: read`

This is sufficient for `actions/checkout` and read-only scanning steps in this file. No additional imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
