### PR TITLE
feat(common): add job fair API

### DIFF
--- a/api/handler/api/common_service.go
+++ b/api/handler/api/common_service.go
@@ -366,3 +366,23 @@ func DeleteToolboxConfig(ctx context.Context, c *app.RequestContext) {
 	}
 	pack.RespSuccess(c)
 }
+
+// GetJobFair .
+// @router /api/v1/common/job-fair [GET]
+func GetJobFair(ctx context.Context, c *app.RequestContext) {
+	var req api.GetJobFairRequest
+	if err := c.BindAndValidate(&req); err != nil {
+		pack.RespError(c, errno.ParamError.WithError(err))
+		return
+	}
+
+	events, err := rpc.GetJobFairRPC(ctx, &common.JobFairRequest{Month: req.Month})
+	if err != nil {
+		pack.RespError(c, err)
+		return
+	}
+
+	resp := new(api.GetJobFairResponse)
+	resp.Events = pack.BuildJobFairEvents(events)
+	pack.RespList(c, resp)
+}

--- a/api/handler/api/common_service_test.go
+++ b/api/handler/api/common_service_test.go
@@ -226,7 +226,7 @@ func TestGetJobFair(t *testing.T) {
 					Title:     "招聘会",
 					Place:     "旗山校区",
 					Time:      "19:00",
-					StartsAt:  "2026-09-04T19:00:00+08:00",
+					StartsAt:  1788519600,
 					DateKey:   "2026-09-04",
 					DetailUrl: "http://example.test/event-1",
 				}}, nil
@@ -236,7 +236,7 @@ func TestGetJobFair(t *testing.T) {
 		res := ut.PerformRequest(router, consts.MethodGet, "/api/v1/common/job-fair?month=2026-09", nil)
 		assert.Equal(t, consts.StatusOK, res.Result().StatusCode())
 		assert.Contains(t, string(res.Result().Body()), `"code":"10000"`)
-		assert.Contains(t, string(res.Result().Body()), `"starts_at":"2026-09-04T19:00:00+08:00"`)
+		assert.Contains(t, string(res.Result().Body()), `"starts_at":1788519600`)
 	})
 
 	t.Run("rejects missing month", func(t *testing.T) {

--- a/api/handler/api/common_service_test.go
+++ b/api/handler/api/common_service_test.go
@@ -212,6 +212,40 @@ func TestGetNotice(t *testing.T) {
 	}
 }
 
+func TestGetJobFair(t *testing.T) {
+	router := route.NewEngine(&config.Options{})
+	router.GET("/api/v1/common/job-fair", GetJobFair)
+
+	defer mockey.UnPatchAll()
+	t.Run("forwards month and returns events", func(t *testing.T) {
+		mockey.Mock(rpc.GetJobFairRPC).To(
+			func(_ context.Context, req *common.JobFairRequest) ([]*model.JobFairEvent, error) {
+				assert.Equal(t, "2026-09", req.Month)
+				return []*model.JobFairEvent{{
+					Id:        "event-1",
+					Title:     "招聘会",
+					Place:     "旗山校区",
+					Time:      "19:00",
+					StartsAt:  "2026-09-04T19:00:00+08:00",
+					DateKey:   "2026-09-04",
+					DetailUrl: "http://example.test/event-1",
+				}}, nil
+			},
+		).Build()
+
+		res := ut.PerformRequest(router, consts.MethodGet, "/api/v1/common/job-fair?month=2026-09", nil)
+		assert.Equal(t, consts.StatusOK, res.Result().StatusCode())
+		assert.Contains(t, string(res.Result().Body()), `"code":"10000"`)
+		assert.Contains(t, string(res.Result().Body()), `"starts_at":"2026-09-04T19:00:00+08:00"`)
+	})
+
+	t.Run("rejects missing month", func(t *testing.T) {
+		res := ut.PerformRequest(router, consts.MethodGet, "/api/v1/common/job-fair", nil)
+		assert.Equal(t, consts.StatusOK, res.Result().StatusCode())
+		assert.Contains(t, string(res.Result().Body()), `"code":"20001"`)
+	})
+}
+
 func TestGetContributorInfo(t *testing.T) {
 	type testCase struct {
 		name           string

--- a/api/model/api/api.go
+++ b/api/model/api/api.go
@@ -3898,6 +3898,50 @@ func (p *GetNoticeResponse) String() string {
 	return fmt.Sprintf("GetNoticeResponse(%+v)", *p)
 }
 
+type GetJobFairRequest struct {
+	Month string `thrift:"month,1,required" json:"month,required" query:"month,required"`
+}
+
+func NewGetJobFairRequest() *GetJobFairRequest {
+	return &GetJobFairRequest{}
+}
+
+func (p *GetJobFairRequest) InitDefault() {
+}
+
+func (p *GetJobFairRequest) GetMonth() (v string) {
+	return p.Month
+}
+
+func (p *GetJobFairRequest) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("GetJobFairRequest(%+v)", *p)
+}
+
+type GetJobFairResponse struct {
+	Events []*model.JobFairEvent `thrift:"events,1,required,list<model.JobFairEvent>" form:"events,required" json:"events,required" query:"events,required"`
+}
+
+func NewGetJobFairResponse() *GetJobFairResponse {
+	return &GetJobFairResponse{}
+}
+
+func (p *GetJobFairResponse) InitDefault() {
+}
+
+func (p *GetJobFairResponse) GetEvents() (v []*model.JobFairEvent) {
+	return p.Events
+}
+
+func (p *GetJobFairResponse) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("GetJobFairResponse(%+v)", *p)
+}
+
 type GetContributorInfoRequest struct {
 }
 
@@ -5396,6 +5440,8 @@ type CommonService interface {
 	GetTerm(ctx context.Context, req *TermRequest) (r *TermResponse, err error)
 	// 获取教务处通知
 	GetNotice(ctx context.Context, req *GetNoticeRequst) (r *GetNoticeResponse, err error)
+	// 获取招聘会/宣讲会
+	GetJobFair(ctx context.Context, req *GetJobFairRequest) (r *GetJobFairResponse, err error)
 	// 获取贡献者列表
 	GetContributorInfo(ctx context.Context, req *GetContributorInfoRequest) (r *GetContributorInfoResponse, err error)
 	// 获取工具箱配置

--- a/api/model/model/model.go
+++ b/api/model/model/model.go
@@ -1486,7 +1486,7 @@ type JobFairEvent struct {
 	Title     string `thrift:"title,2,required" form:"title,required" json:"title,required" query:"title,required"`
 	Place     string `thrift:"place,3,required" form:"place,required" json:"place,required" query:"place,required"`
 	Time      string `thrift:"time,4,required" form:"time,required" json:"time,required" query:"time,required"`
-	StartsAt  string `thrift:"starts_at,5,required" form:"starts_at,required" json:"starts_at,required" query:"starts_at,required"`
+	StartsAt  int64  `thrift:"starts_at,5,required" form:"starts_at,required" json:"starts_at,required" query:"starts_at,required"`
 	DateKey   string `thrift:"date_key,6,required" form:"date_key,required" json:"date_key,required" query:"date_key,required"`
 	DetailURL string `thrift:"detail_url,7,required" form:"detail_url,required" json:"detail_url,required" query:"detail_url,required"`
 }
@@ -1514,7 +1514,7 @@ func (p *JobFairEvent) GetTime() (v string) {
 	return p.Time
 }
 
-func (p *JobFairEvent) GetStartsAt() (v string) {
+func (p *JobFairEvent) GetStartsAt() (v int64) {
 	return p.StartsAt
 }
 

--- a/api/model/model/model.go
+++ b/api/model/model/model.go
@@ -1480,6 +1480,59 @@ func (p *NoticeInfo) String() string {
 	return fmt.Sprintf("NoticeInfo(%+v)", *p)
 }
 
+// 招聘会/宣讲会活动
+type JobFairEvent struct {
+	ID        string `thrift:"id,1,required" form:"id,required" json:"id,required" query:"id,required"`
+	Title     string `thrift:"title,2,required" form:"title,required" json:"title,required" query:"title,required"`
+	Place     string `thrift:"place,3,required" form:"place,required" json:"place,required" query:"place,required"`
+	Time      string `thrift:"time,4,required" form:"time,required" json:"time,required" query:"time,required"`
+	StartsAt  string `thrift:"starts_at,5,required" form:"starts_at,required" json:"starts_at,required" query:"starts_at,required"`
+	DateKey   string `thrift:"date_key,6,required" form:"date_key,required" json:"date_key,required" query:"date_key,required"`
+	DetailURL string `thrift:"detail_url,7,required" form:"detail_url,required" json:"detail_url,required" query:"detail_url,required"`
+}
+
+func NewJobFairEvent() *JobFairEvent {
+	return &JobFairEvent{}
+}
+
+func (p *JobFairEvent) InitDefault() {
+}
+
+func (p *JobFairEvent) GetID() (v string) {
+	return p.ID
+}
+
+func (p *JobFairEvent) GetTitle() (v string) {
+	return p.Title
+}
+
+func (p *JobFairEvent) GetPlace() (v string) {
+	return p.Place
+}
+
+func (p *JobFairEvent) GetTime() (v string) {
+	return p.Time
+}
+
+func (p *JobFairEvent) GetStartsAt() (v string) {
+	return p.StartsAt
+}
+
+func (p *JobFairEvent) GetDateKey() (v string) {
+	return p.DateKey
+}
+
+func (p *JobFairEvent) GetDetailURL() (v string) {
+	return p.DetailURL
+}
+
+func (p *JobFairEvent) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("JobFairEvent(%+v)", *p)
+}
+
 type Contributor struct {
 	Name          string `thrift:"name,1" form:"name" json:"name" query:"name"`
 	AvatarURL     string `thrift:"avatar_url,2" form:"avatar_url" json:"avatar_url" query:"avatar_url"`

--- a/api/pack/common.go
+++ b/api/pack/common.go
@@ -77,6 +77,22 @@ func BuildContributors(contributors []*model.Contributor) []*api.Contributor {
 	return base.BuildTypeList(contributors, BuildContributor)
 }
 
+func BuildJobFairEvents(events []*model.JobFairEvent) []*api.JobFairEvent {
+	result := make([]*api.JobFairEvent, 0, len(events))
+	for _, event := range events {
+		result = append(result, &api.JobFairEvent{
+			ID:        event.Id,
+			Title:     event.Title,
+			Place:     event.Place,
+			Time:      event.Time,
+			StartsAt:  event.StartsAt,
+			DateKey:   event.DateKey,
+			DetailURL: event.DetailUrl,
+		})
+	}
+	return result
+}
+
 func BuildToolboxConfig(config *model.ToolboxConfig) *api.ToolboxConfig {
 	return &api.ToolboxConfig{
 		ToolID:    config.ToolId,

--- a/api/router/api/api.go
+++ b/api/router/api/api.go
@@ -47,6 +47,7 @@ func Register(r *server.Hertz) {
 			{
 				_common := _v1.Group("/common", _commonMw()...)
 				_common.GET("/contributor", append(_getcontributorinfoMw(), api.GetContributorInfo)...)
+				_common.GET("/job-fair", append(_getjobfairMw(), api.GetJobFair)...)
 				_common.GET("/notice", append(_getnoticeMw(), api.GetNotice)...)
 				_common.POST("/signed-location-api-url", append(_getsignedlocationapiurlMw(), api.GetSignedLocationApiUrl)...)
 				{

--- a/api/router/api/middleware.go
+++ b/api/router/api/middleware.go
@@ -631,3 +631,8 @@ func _listimageMw() []app.HandlerFunc {
 	// your code...
 	return nil
 }
+
+func _getjobfairMw() []app.HandlerFunc {
+	// your code...
+	return nil
+}

--- a/api/rpc/common.go
+++ b/api/rpc/common.go
@@ -110,6 +110,18 @@ func GetNoticesRPC(ctx context.Context, req *common.NoticeRequest) ([]*model.Not
 	return resp.Notices, resp.Total, nil
 }
 
+func GetJobFairRPC(ctx context.Context, req *common.JobFairRequest) ([]*model.JobFairEvent, error) {
+	resp, err := commonClient.GetJobFair(ctx, req)
+	if err != nil {
+		logger.WithCtx(ctx).Errorf("GetJobFairRPC: RPC called failed: %v", err.Error())
+		return nil, errno.InternalServiceError.WithMessage(err.Error())
+	}
+	if !utils.IsSuccess(resp.Base) {
+		return nil, errno.NewErrNo(resp.Base.Code, resp.Base.Msg)
+	}
+	return resp.Events, nil
+}
+
 func GetContributorRPC(ctx context.Context, req *common.GetContributorInfoRequest) (*common.GetContributorInfoResponse, error) {
 	resp, err := commonClient.GetContributorInfo(ctx, req)
 	if err != nil {

--- a/api/rpc/common_test.go
+++ b/api/rpc/common_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 The west2-online Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cloudwego/kitex/client/callopt"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/west2-online/fzuhelper-server/kitex_gen/common"
+	"github.com/west2-online/fzuhelper-server/kitex_gen/common/commonservice"
+	"github.com/west2-online/fzuhelper-server/kitex_gen/model"
+	"github.com/west2-online/fzuhelper-server/pkg/errno"
+)
+
+type jobFairClientStub struct {
+	commonservice.Client
+	response *common.JobFairResponse
+	err      error
+}
+
+func (c *jobFairClientStub) GetJobFair(
+	context.Context,
+	*common.JobFairRequest,
+	...callopt.Option,
+) (*common.JobFairResponse, error) {
+	return c.response, c.err
+}
+
+func TestGetJobFairRPCPreservesServiceErrorCode(t *testing.T) {
+	originalClient := commonClient
+	defer func() { commonClient = originalClient }()
+
+	commonClient = &jobFairClientStub{response: &common.JobFairResponse{
+		Base: &model.BaseResp{Code: errno.ParamErrorCode, Msg: "invalid month"},
+	}}
+
+	_, err := GetJobFairRPC(context.Background(), &common.JobFairRequest{Month: "2026/09"})
+	assert.Equal(t, int64(errno.ParamErrorCode), errno.ConvertErr(err).ErrorCode)
+}

--- a/idl/api.thrift
+++ b/idl/api.thrift
@@ -700,6 +700,14 @@ struct GetNoticeResponse {
     2: required i64 total
 }
 
+struct GetJobFairRequest {
+    1: required string month (api.query="month")
+}
+
+struct GetJobFairResponse {
+    1: required list<model.JobFairEvent> events
+}
+
 struct GetContributorInfoRequest {
 }
 
@@ -810,6 +818,8 @@ service CommonService {
     TermResponse GetTerm(1: TermRequest req) (api.get="/api/v1/terms/info")
     // 获取教务处通知
     GetNoticeResponse GetNotice(1: GetNoticeRequst req) (api.get="/api/v1/common/notice")
+    // 获取招聘会/宣讲会
+    GetJobFairResponse GetJobFair(1: GetJobFairRequest req) (api.get="/api/v1/common/job-fair")
     // 获取贡献者列表
     GetContributorInfoResponse GetContributorInfo(1: GetContributorInfoRequest req)(api.get="/api/v1/common/contributor")
      // 获取工具箱配置

--- a/idl/common.thrift
+++ b/idl/common.thrift
@@ -54,6 +54,16 @@ struct NoticeResponse {
     3: required i64 total
 }
 
+// 招聘会/宣讲会
+struct JobFairRequest {
+    1: required string month
+}
+
+struct JobFairResponse {
+    1: required model.BaseResp base
+    2: required list<model.JobFairEvent> events
+}
+
 // 获取贡献者列表
 struct GetContributorInfoRequest {
 }
@@ -180,6 +190,8 @@ service CommonService {
     TermResponse GetTerm(1: TermRequest req)
     // 教务处教学通知
     NoticeResponse GetNotices(1: NoticeRequest req)
+    // 招聘会/宣讲会
+    JobFairResponse GetJobFair(1: JobFairRequest req)
     // 获取贡献者列表
     GetContributorInfoResponse GetContributorInfo(1: GetContributorInfoRequest req)
     // 获取工具箱配置

--- a/idl/model.thrift
+++ b/idl/model.thrift
@@ -249,7 +249,7 @@ struct JobFairEvent {
     2: required string title
     3: required string place
     4: required string time
-    5: required string starts_at
+    5: required i64 starts_at
     6: required string date_key
     7: required string detail_url
 }

--- a/idl/model.thrift
+++ b/idl/model.thrift
@@ -243,6 +243,17 @@ struct NoticeInfo {
     3: optional string date
 }
 
+// 招聘会/宣讲会活动
+struct JobFairEvent {
+    1: required string id
+    2: required string title
+    3: required string place
+    4: required string time
+    5: required string starts_at
+    6: required string date_key
+    7: required string detail_url
+}
+
 struct Contributor {
   1: string name
   2: string avatar_url

--- a/internal/common/handler.go
+++ b/internal/common/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/west2-online/fzuhelper-server/internal/common/pack"
 	"github.com/west2-online/fzuhelper-server/internal/common/service"
 	"github.com/west2-online/fzuhelper-server/kitex_gen/common"
+	kitexmodel "github.com/west2-online/fzuhelper-server/kitex_gen/model"
 	"github.com/west2-online/fzuhelper-server/pkg/base"
 	"github.com/west2-online/fzuhelper-server/pkg/constants"
 	"github.com/west2-online/fzuhelper-server/pkg/db/model"
@@ -159,6 +160,23 @@ func (s *CommonServiceImpl) GetNotices(ctx context.Context, req *common.NoticeRe
 	resp.Notices = pack.BuildNoticeList(result.list)
 	resp.Total = int64(result.total)
 	return resp, err
+}
+
+func (s *CommonServiceImpl) GetJobFair(ctx context.Context, req *common.JobFairRequest) (resp *common.JobFairResponse, err error) {
+	resp = common.NewJobFairResponse()
+
+	key := singleflight.Key(constants.SingleflightJobFairPrefix, req.Month)
+	events, err := singleflight.Do(key, func() ([]*kitexmodel.JobFairEvent, error) {
+		return service.NewCommonService(ctx, s.ClientSet, s.taskQueue).GetJobFair(req.Month)
+	})
+	if err != nil {
+		resp.Base = base.BuildBaseResp(fmt.Errorf("Common.GetJobFair: get job fair failed: %w", err))
+		return resp, nil
+	}
+
+	resp.Base = base.BuildSuccessResp()
+	resp.Events = events
+	return resp, nil
 }
 
 func (s *CommonServiceImpl) GetContributorInfo(ctx context.Context,

--- a/internal/common/service/get_job_fair.go
+++ b/internal/common/service/get_job_fair.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/west2-online/fzuhelper-server/kitex_gen/model"
 	"github.com/west2-online/fzuhelper-server/pkg/errno"
+	"github.com/west2-online/fzuhelper-server/pkg/logger"
 )
 
 const (
@@ -59,6 +60,18 @@ func (s *CommonService) GetJobFair(month string) ([]*model.JobFairEvent, error) 
 	parsedMonth, err := time.Parse("2006-01", month)
 	if err != nil || parsedMonth.Format("2006-01") != month {
 		return nil, errno.ParamError.WithMessage(fmt.Sprintf("invalid month %q, expected YYYY-MM", month))
+	}
+
+	cacheKey := ""
+	if s.cache != nil && s.cache.Common != nil {
+		cacheKey = s.cache.Common.JobFairKey(month)
+		if s.cache.IsKeyExist(s.ctx, cacheKey) {
+			events, cacheErr := s.cache.Common.GetJobFair(s.ctx, cacheKey)
+			if cacheErr != nil {
+				return nil, fmt.Errorf("service get job fair: read cache failed: %w", cacheErr)
+			}
+			return events, nil
+		}
 	}
 
 	req := protocol.AcquireRequest()
@@ -116,10 +129,15 @@ func (s *CommonService) GetJobFair(month string) ([]*model.JobFairEvent, error) 
 			Title:     normalizeJobFairText(sourceEvent.Title),
 			Place:     normalizeJobFairText(sourceEvent.Place),
 			Time:      sourceEvent.Time,
-			StartsAt:  startsAt.Format(time.RFC3339),
+			StartsAt:  startsAt.Unix(),
 			DateKey:   startsAt.Format(time.DateOnly),
 			DetailUrl: detailURL + "?id=" + url.QueryEscape(sourceEvent.ID),
 		})
+	}
+	if cacheKey != "" {
+		if cacheErr := s.cache.Common.SetJobFair(s.ctx, cacheKey, events); cacheErr != nil {
+			logger.Errorf("service get job fair: write cache failed: %v", cacheErr)
+		}
 	}
 
 	return events, nil

--- a/internal/common/service/get_job_fair.go
+++ b/internal/common/service/get_job_fair.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2024 The west2-online Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+	"html"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/bytedance/sonic"
+	hertzconfig "github.com/cloudwego/hertz/pkg/common/config"
+	"github.com/cloudwego/hertz/pkg/protocol"
+	"github.com/cloudwego/hertz/pkg/protocol/consts"
+
+	"github.com/west2-online/fzuhelper-server/kitex_gen/model"
+	"github.com/west2-online/fzuhelper-server/pkg/errno"
+)
+
+const (
+	jobFairSourceURL      = "http://fjrclh.fzu.edu.cn/CmsInterface/getDateZPHKeynoteList_month"
+	jobFairDetailURL      = "http://fjrclh.fzu.edu.cn/cms/zphdetail.html"
+	lectureDetailURL      = "http://fjrclh.fzu.edu.cn/cms/xjhdetail.html"
+	jobFairRequestTimeout = 10 * time.Second
+)
+
+var chinaStandardTime = time.FixedZone("Asia/Shanghai", int(8*time.Hour/time.Second))
+
+type jobFairSourceItem struct {
+	ID        string  `json:"id"`
+	Title     *string `json:"title"`
+	Place     *string `json:"place"`
+	StartTime string  `json:"start_time"`
+	Time      string  `json:"time"`
+	ZPHVal    string  `json:"zphval"`
+}
+
+type jobFairSourceResponse struct {
+	Success bool                `json:"success"`
+	Events  []jobFairSourceItem `json:"zhaopinhui_keynoteList"`
+}
+
+func (s *CommonService) GetJobFair(month string) ([]*model.JobFairEvent, error) {
+	parsedMonth, err := time.Parse("2006-01", month)
+	if err != nil || parsedMonth.Format("2006-01") != month {
+		return nil, errno.ParamError.WithMessage(fmt.Sprintf("invalid month %q, expected YYYY-MM", month))
+	}
+
+	req := protocol.AcquireRequest()
+	resp := protocol.AcquireResponse()
+	defer func() {
+		protocol.ReleaseRequest(req)
+		protocol.ReleaseResponse(resp)
+	}()
+
+	form := url.Values{"dateday": {strings.Replace(month, "-", "/", 1)}}
+	req.SetMethod(consts.MethodPost)
+	req.Header.SetContentTypeBytes([]byte("application/x-www-form-urlencoded; charset=UTF-8"))
+	req.SetBodyString(form.Encode())
+	req.SetRequestURI(jobFairSourceURL)
+	req.SetOptions(
+		hertzconfig.WithDialTimeout(jobFairRequestTimeout),
+		hertzconfig.WithReadTimeout(jobFairRequestTimeout),
+		hertzconfig.WithWriteTimeout(jobFairRequestTimeout),
+		hertzconfig.WithRequestTimeout(jobFairRequestTimeout),
+	)
+
+	if err = s.httpClient.Do(s.ctx, req, resp); err != nil {
+		return nil, fmt.Errorf("service get job fair: request source failed: %w", err)
+	}
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, fmt.Errorf("service get job fair: unexpected status code %d", resp.StatusCode())
+	}
+
+	var sourceResponse jobFairSourceResponse
+	if err = sonic.Unmarshal(resp.Body(), &sourceResponse); err != nil {
+		return nil, fmt.Errorf("service get job fair: unmarshal response failed: %w", err)
+	}
+	if !sourceResponse.Success {
+		return nil, fmt.Errorf("service get job fair: source response was unsuccessful")
+	}
+
+	events := make([]*model.JobFairEvent, 0, len(sourceResponse.Events))
+	for _, sourceEvent := range sourceResponse.Events {
+		startsAt, parseErr := time.ParseInLocation(
+			"20060102 15:04",
+			sourceEvent.StartTime+" "+sourceEvent.Time,
+			chinaStandardTime,
+		)
+		if parseErr != nil {
+			return nil, fmt.Errorf("service get job fair: parse event time failed for %q: %w", sourceEvent.ID, parseErr)
+		}
+
+		detailURL := jobFairDetailURL
+		if sourceEvent.ZPHVal == "3" {
+			detailURL = lectureDetailURL
+		}
+
+		events = append(events, &model.JobFairEvent{
+			Id:        sourceEvent.ID,
+			Title:     normalizeJobFairText(sourceEvent.Title),
+			Place:     normalizeJobFairText(sourceEvent.Place),
+			Time:      sourceEvent.Time,
+			StartsAt:  startsAt.Format(time.RFC3339),
+			DateKey:   startsAt.Format(time.DateOnly),
+			DetailUrl: detailURL + "?id=" + url.QueryEscape(sourceEvent.ID),
+		})
+	}
+
+	return events, nil
+}
+
+func normalizeJobFairText(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(html.UnescapeString(*value))
+}

--- a/internal/common/service/get_job_fair_test.go
+++ b/internal/common/service/get_job_fair_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2024 The west2-online Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bytedance/mockey"
+	"github.com/cloudwego/hertz/pkg/app/client"
+	"github.com/cloudwego/hertz/pkg/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/west2-online/fzuhelper-server/kitex_gen/model"
+	"github.com/west2-online/fzuhelper-server/pkg/base"
+	"github.com/west2-online/fzuhelper-server/pkg/taskqueue"
+)
+
+func TestGetJobFair(t *testing.T) {
+	type testCase struct {
+		name                string
+		month               string
+		responseStatus      int
+		responseBody        string
+		requestError        error
+		expectRequestBody   string
+		expectEvents        []*model.JobFairEvent
+		expectErrorContains string
+	}
+
+	testCases := []testCase{
+		{
+			name:              "successfully_normalizes_source_events",
+			month:             "2026-09",
+			responseStatus:    200,
+			expectRequestBody: "dateday=2026%2F09",
+			responseBody: `{
+				"success": true,
+				"zhaopinhui_keynoteList": [
+					{
+						"id": "lecture-id",
+						"title": "A&amp;B&mdash;2027届宣讲会",
+						"place": null,
+						"start_time": "20260904",
+						"time": "19:00",
+						"zphval": "3"
+					},
+					{
+						"id": "job-fair-id",
+						"title": "秋季招聘会",
+						"place": "  旗山校区  ",
+						"start_time": "20260905",
+						"time": "09:30",
+						"zphval": "1"
+					}
+				]
+			}`,
+			expectEvents: []*model.JobFairEvent{
+				{
+					Id:        "lecture-id",
+					Title:     "A&B—2027届宣讲会",
+					Place:     "",
+					Time:      "19:00",
+					StartsAt:  "2026-09-04T19:00:00+08:00",
+					DateKey:   "2026-09-04",
+					DetailUrl: "http://fjrclh.fzu.edu.cn/cms/xjhdetail.html?id=lecture-id",
+				},
+				{
+					Id:        "job-fair-id",
+					Title:     "秋季招聘会",
+					Place:     "旗山校区",
+					Time:      "09:30",
+					StartsAt:  "2026-09-05T09:30:00+08:00",
+					DateKey:   "2026-09-05",
+					DetailUrl: "http://fjrclh.fzu.edu.cn/cms/zphdetail.html?id=job-fair-id",
+				},
+			},
+		},
+		{
+			name:                "rejects_invalid_month",
+			month:               "2026/09",
+			expectErrorContains: "invalid month",
+		},
+		{
+			name:                "returns_request_error",
+			month:               "2026-09",
+			requestError:        errors.New("connection refused"),
+			expectRequestBody:   "dateday=2026%2F09",
+			expectErrorContains: "request source failed",
+		},
+		{
+			name:                "rejects_non_success_status",
+			month:               "2026-09",
+			responseStatus:      503,
+			expectRequestBody:   "dateday=2026%2F09",
+			expectErrorContains: "unexpected status code 503",
+		},
+		{
+			name:                "rejects_invalid_json",
+			month:               "2026-09",
+			responseStatus:      200,
+			responseBody:        "not-json",
+			expectRequestBody:   "dateday=2026%2F09",
+			expectErrorContains: "unmarshal response failed",
+		},
+		{
+			name:                "rejects_unsuccessful_source_response",
+			month:               "2026-09",
+			responseStatus:      200,
+			responseBody:        `{"success":false,"zhaopinhui_keynoteList":[]}`,
+			expectRequestBody:   "dateday=2026%2F09",
+			expectErrorContains: "source response was unsuccessful",
+		},
+		{
+			name:           "rejects_invalid_event_time",
+			month:          "2026-09",
+			responseStatus: 200,
+			responseBody: `{
+				"success": true,
+				"zhaopinhui_keynoteList": [{
+					"id": "bad-time",
+					"title": "无效时间",
+					"place": "",
+					"start_time": "20260999",
+					"time": "19:00",
+					"zphval": "3"
+				}]
+			}`,
+			expectRequestBody:   "dateday=2026%2F09",
+			expectErrorContains: "parse event time failed",
+		},
+	}
+
+	httpClient, err := client.NewClient()
+	require.NoError(t, err)
+
+	defer mockey.UnPatchAll()
+	for _, tc := range testCases {
+		mockey.PatchConvey(tc.name, t, func() {
+			mockey.Mock((*client.Client).Do).To(
+				func(_ *client.Client, _ context.Context, req *protocol.Request, resp *protocol.Response) error {
+					assert.Equal(t, tc.expectRequestBody, string(req.Body()))
+					if tc.requestError != nil {
+						return tc.requestError
+					}
+					resp.SetStatusCode(tc.responseStatus)
+					resp.SetBodyString(tc.responseBody)
+					return nil
+				},
+			).Build()
+
+			commonService := NewCommonService(
+				context.Background(),
+				&base.ClientSet{HzClient: httpClient},
+				new(taskqueue.BaseTaskQueue),
+			)
+			events, err := commonService.GetJobFair(tc.month)
+
+			if tc.expectErrorContains != "" {
+				assert.ErrorContains(t, err, tc.expectErrorContains)
+				assert.Nil(t, events)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectEvents, events)
+		})
+	}
+}

--- a/internal/common/service/get_job_fair_test.go
+++ b/internal/common/service/get_job_fair_test.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/west2-online/fzuhelper-server/kitex_gen/model"
 	"github.com/west2-online/fzuhelper-server/pkg/base"
+	"github.com/west2-online/fzuhelper-server/pkg/cache"
+	commoncache "github.com/west2-online/fzuhelper-server/pkg/cache/common"
 	"github.com/west2-online/fzuhelper-server/pkg/taskqueue"
 )
 
@@ -77,7 +79,7 @@ func TestGetJobFair(t *testing.T) {
 					Title:     "A&B—2027届宣讲会",
 					Place:     "",
 					Time:      "19:00",
-					StartsAt:  "2026-09-04T19:00:00+08:00",
+					StartsAt:  1788519600,
 					DateKey:   "2026-09-04",
 					DetailUrl: "http://fjrclh.fzu.edu.cn/cms/xjhdetail.html?id=lecture-id",
 				},
@@ -86,7 +88,7 @@ func TestGetJobFair(t *testing.T) {
 					Title:     "秋季招聘会",
 					Place:     "旗山校区",
 					Time:      "09:30",
-					StartsAt:  "2026-09-05T09:30:00+08:00",
+					StartsAt:  1788571800,
 					DateKey:   "2026-09-05",
 					DetailUrl: "http://fjrclh.fzu.edu.cn/cms/zphdetail.html?id=job-fair-id",
 				},
@@ -182,4 +184,69 @@ func TestGetJobFair(t *testing.T) {
 			assert.Equal(t, tc.expectEvents, events)
 		})
 	}
+}
+
+func TestGetJobFairReturnsCachedEvents(t *testing.T) {
+	httpClient, err := client.NewClient()
+	require.NoError(t, err)
+	cachedEvents := []*model.JobFairEvent{{Id: "cached-event"}}
+
+	defer mockey.UnPatchAll()
+	mockey.Mock((*cache.Cache).IsKeyExist).Return(true).Build()
+	mockey.Mock((*commoncache.CacheCommon).GetJobFair).Return(cachedEvents, nil).Build()
+
+	sourceCalled := false
+	mockey.Mock((*client.Client).Do).To(
+		func(_ *client.Client, _ context.Context, _ *protocol.Request, _ *protocol.Response) error {
+			sourceCalled = true
+			return errors.New("source should not be called on cache hit")
+		},
+	).Build()
+
+	commonService := NewCommonService(
+		context.Background(),
+		&base.ClientSet{CacheClient: &cache.Cache{Common: new(commoncache.CacheCommon)}, HzClient: httpClient},
+		new(taskqueue.BaseTaskQueue),
+	)
+	events, err := commonService.GetJobFair("2026-09")
+
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "cached-event", events[0].Id)
+	assert.False(t, sourceCalled)
+}
+
+func TestGetJobFairCachesSourceEvents(t *testing.T) {
+	httpClient, err := client.NewClient()
+	require.NoError(t, err)
+
+	defer mockey.UnPatchAll()
+	mockey.Mock((*cache.Cache).IsKeyExist).Return(false).Build()
+	mockey.Mock((*client.Client).Do).To(
+		func(_ *client.Client, _ context.Context, _ *protocol.Request, resp *protocol.Response) error {
+			resp.SetStatusCode(200)
+			resp.SetBodyString(`{"success":true,"zhaopinhui_keynoteList":[]}`)
+			return nil
+		},
+	).Build()
+
+	cacheSet := false
+	mockey.Mock((*commoncache.CacheCommon).SetJobFair).To(
+		func(_ *commoncache.CacheCommon, _ context.Context, key string, events []*model.JobFairEvent) error {
+			assert.Equal(t, "common:job_fair:2026-09", key)
+			assert.Empty(t, events)
+			cacheSet = true
+			return nil
+		},
+	).Build()
+
+	commonService := NewCommonService(
+		context.Background(),
+		&base.ClientSet{CacheClient: &cache.Cache{Common: new(commoncache.CacheCommon)}, HzClient: httpClient},
+		new(taskqueue.BaseTaskQueue),
+	)
+	_, err = commonService.GetJobFair("2026-09")
+
+	require.NoError(t, err)
+	assert.True(t, cacheSet)
 }

--- a/internal/course/service/get_term_info_test.go
+++ b/internal/course/service/get_term_info_test.go
@@ -60,6 +60,10 @@ func (m *mockCommonClient) GetNotices(context.Context, *common.NoticeRequest, ..
 	return nil, errors.New("not implemented")
 }
 
+func (m *mockCommonClient) GetJobFair(context.Context, *common.JobFairRequest, ...callopt.Option) (*common.JobFairResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (m *mockCommonClient) GetSignedLocationApiUrl(
 	context.Context,
 	*common.GetSignedLocationApiUrlRequest,

--- a/kitex_gen/common/common.go
+++ b/kitex_gen/common/common.go
@@ -379,6 +379,73 @@ func (p *NoticeResponse) String() string {
 	return fmt.Sprintf("NoticeResponse(%+v)", *p)
 }
 
+type JobFairRequest struct {
+	Month string `thrift:"month,1,required" frugal:"1,required,string" json:"month"`
+}
+
+func NewJobFairRequest() *JobFairRequest {
+	return &JobFairRequest{}
+}
+
+func (p *JobFairRequest) InitDefault() {
+}
+
+func (p *JobFairRequest) GetMonth() (v string) {
+	return p.Month
+}
+func (p *JobFairRequest) SetMonth(val string) {
+	p.Month = val
+}
+
+func (p *JobFairRequest) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("JobFairRequest(%+v)", *p)
+}
+
+type JobFairResponse struct {
+	Base   *model.BaseResp       `thrift:"base,1,required" frugal:"1,required,model.BaseResp" json:"base"`
+	Events []*model.JobFairEvent `thrift:"events,2,required" frugal:"2,required,list<model.JobFairEvent>" json:"events"`
+}
+
+func NewJobFairResponse() *JobFairResponse {
+	return &JobFairResponse{}
+}
+
+func (p *JobFairResponse) InitDefault() {
+}
+
+var JobFairResponse_Base_DEFAULT *model.BaseResp
+
+func (p *JobFairResponse) GetBase() (v *model.BaseResp) {
+	if !p.IsSetBase() {
+		return JobFairResponse_Base_DEFAULT
+	}
+	return p.Base
+}
+
+func (p *JobFairResponse) GetEvents() (v []*model.JobFairEvent) {
+	return p.Events
+}
+func (p *JobFairResponse) SetBase(val *model.BaseResp) {
+	p.Base = val
+}
+func (p *JobFairResponse) SetEvents(val []*model.JobFairEvent) {
+	p.Events = val
+}
+
+func (p *JobFairResponse) IsSetBase() bool {
+	return p.Base != nil
+}
+
+func (p *JobFairResponse) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("JobFairResponse(%+v)", *p)
+}
+
 type GetContributorInfoRequest struct {
 }
 
@@ -1510,6 +1577,8 @@ type CommonService interface {
 	GetTerm(ctx context.Context, req *TermRequest) (r *TermResponse, err error)
 
 	GetNotices(ctx context.Context, req *NoticeRequest) (r *NoticeResponse, err error)
+
+	GetJobFair(ctx context.Context, req *JobFairRequest) (r *JobFairResponse, err error)
 
 	GetContributorInfo(ctx context.Context, req *GetContributorInfoRequest) (r *GetContributorInfoResponse, err error)
 

--- a/kitex_gen/common/commonservice/client.go
+++ b/kitex_gen/common/commonservice/client.go
@@ -35,6 +35,7 @@ type Client interface {
 	GetTermsList(ctx context.Context, req *common.TermListRequest, callOptions ...callopt.Option) (r *common.TermListResponse, err error)
 	GetTerm(ctx context.Context, req *common.TermRequest, callOptions ...callopt.Option) (r *common.TermResponse, err error)
 	GetNotices(ctx context.Context, req *common.NoticeRequest, callOptions ...callopt.Option) (r *common.NoticeResponse, err error)
+	GetJobFair(ctx context.Context, req *common.JobFairRequest, callOptions ...callopt.Option) (r *common.JobFairResponse, err error)
 	GetContributorInfo(ctx context.Context, req *common.GetContributorInfoRequest, callOptions ...callopt.Option) (r *common.GetContributorInfoResponse, err error)
 	GetToolboxConfig(ctx context.Context, req *common.GetToolboxConfigRequest, callOptions ...callopt.Option) (r *common.GetToolboxConfigResponse, err error)
 	CreateToolboxConfig(ctx context.Context, req *common.CreateToolboxConfigRequest, callOptions ...callopt.Option) (r *common.CreateToolboxConfigResponse, err error)
@@ -103,6 +104,11 @@ func (p *kCommonServiceClient) GetTerm(ctx context.Context, req *common.TermRequ
 func (p *kCommonServiceClient) GetNotices(ctx context.Context, req *common.NoticeRequest, callOptions ...callopt.Option) (r *common.NoticeResponse, err error) {
 	ctx = client.NewCtxWithCallOptions(ctx, callOptions)
 	return p.kClient.GetNotices(ctx, req)
+}
+
+func (p *kCommonServiceClient) GetJobFair(ctx context.Context, req *common.JobFairRequest, callOptions ...callopt.Option) (r *common.JobFairResponse, err error) {
+	ctx = client.NewCtxWithCallOptions(ctx, callOptions)
+	return p.kClient.GetJobFair(ctx, req)
 }
 
 func (p *kCommonServiceClient) GetContributorInfo(ctx context.Context, req *common.GetContributorInfoRequest, callOptions ...callopt.Option) (r *common.GetContributorInfoResponse, err error) {

--- a/kitex_gen/common/commonservice/commonservice.go
+++ b/kitex_gen/common/commonservice/commonservice.go
@@ -73,6 +73,13 @@ var serviceMethods = map[string]kitex.MethodInfo{
 		false,
 		kitex.WithStreamingMode(kitex.StreamingNone),
 	),
+	"GetJobFair": kitex.NewMethodInfo(
+		getJobFairHandler,
+		newCommonServiceGetJobFairArgs,
+		newCommonServiceGetJobFairResult,
+		false,
+		kitex.WithStreamingMode(kitex.StreamingNone),
+	),
 	"GetContributorInfo": kitex.NewMethodInfo(
 		getContributorInfoHandler,
 		newCommonServiceGetContributorInfoArgs,
@@ -310,6 +317,24 @@ func newCommonServiceGetNoticesResult() interface{} {
 	return common.NewCommonServiceGetNoticesResult()
 }
 
+func getJobFairHandler(ctx context.Context, handler interface{}, arg, result interface{}) error {
+	realArg := arg.(*common.CommonServiceGetJobFairArgs)
+	realResult := result.(*common.CommonServiceGetJobFairResult)
+	success, err := handler.(common.CommonService).GetJobFair(ctx, realArg.Req)
+	if err != nil {
+		return err
+	}
+	realResult.Success = success
+	return nil
+}
+func newCommonServiceGetJobFairArgs() interface{} {
+	return common.NewCommonServiceGetJobFairArgs()
+}
+
+func newCommonServiceGetJobFairResult() interface{} {
+	return common.NewCommonServiceGetJobFairResult()
+}
+
 func getContributorInfoHandler(ctx context.Context, handler interface{}, arg, result interface{}) error {
 	realArg := arg.(*common.CommonServiceGetContributorInfoArgs)
 	realResult := result.(*common.CommonServiceGetContributorInfoResult)
@@ -537,6 +562,16 @@ func (p *kClient) GetNotices(ctx context.Context, req *common.NoticeRequest) (r 
 	_args.Req = req
 	var _result common.CommonServiceGetNoticesResult
 	if err = p.c.Call(ctx, "GetNotices", &_args, &_result); err != nil {
+		return
+	}
+	return _result.GetSuccess(), nil
+}
+
+func (p *kClient) GetJobFair(ctx context.Context, req *common.JobFairRequest) (r *common.JobFairResponse, err error) {
+	var _args common.CommonServiceGetJobFairArgs
+	_args.Req = req
+	var _result common.CommonServiceGetJobFairResult
+	if err = p.c.Call(ctx, "GetJobFair", &_args, &_result); err != nil {
 		return
 	}
 	return _result.GetSuccess(), nil

--- a/kitex_gen/common/k-common.go
+++ b/kitex_gen/common/k-common.go
@@ -498,6 +498,82 @@ func (p *CommonServiceGetNoticesResult) GetResult() interface{} {
 	return p.Success
 }
 
+type CommonServiceGetJobFairArgs struct {
+	Req *JobFairRequest `thrift:"req,1" frugal:"1,default,JobFairRequest" json:"req"`
+}
+
+func NewCommonServiceGetJobFairArgs() *CommonServiceGetJobFairArgs {
+	return &CommonServiceGetJobFairArgs{}
+}
+
+func (p *CommonServiceGetJobFairArgs) InitDefault() {
+}
+
+var CommonServiceGetJobFairArgs_Req_DEFAULT *JobFairRequest
+
+func (p *CommonServiceGetJobFairArgs) GetReq() (v *JobFairRequest) {
+	if !p.IsSetReq() {
+		return CommonServiceGetJobFairArgs_Req_DEFAULT
+	}
+	return p.Req
+}
+func (p *CommonServiceGetJobFairArgs) SetReq(val *JobFairRequest) {
+	p.Req = val
+}
+
+func (p *CommonServiceGetJobFairArgs) IsSetReq() bool {
+	return p.Req != nil
+}
+
+func (p *CommonServiceGetJobFairArgs) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("CommonServiceGetJobFairArgs(%+v)", *p)
+}
+
+func (p *CommonServiceGetJobFairArgs) GetFirstArgument() interface{} {
+	return p.Req
+}
+
+type CommonServiceGetJobFairResult struct {
+	Success *JobFairResponse `thrift:"success,0,optional" frugal:"0,optional,JobFairResponse" json:"success,omitempty"`
+}
+
+func NewCommonServiceGetJobFairResult() *CommonServiceGetJobFairResult {
+	return &CommonServiceGetJobFairResult{}
+}
+
+func (p *CommonServiceGetJobFairResult) InitDefault() {
+}
+
+var CommonServiceGetJobFairResult_Success_DEFAULT *JobFairResponse
+
+func (p *CommonServiceGetJobFairResult) GetSuccess() (v *JobFairResponse) {
+	if !p.IsSetSuccess() {
+		return CommonServiceGetJobFairResult_Success_DEFAULT
+	}
+	return p.Success
+}
+func (p *CommonServiceGetJobFairResult) SetSuccess(x interface{}) {
+	p.Success = x.(*JobFairResponse)
+}
+
+func (p *CommonServiceGetJobFairResult) IsSetSuccess() bool {
+	return p.Success != nil
+}
+
+func (p *CommonServiceGetJobFairResult) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("CommonServiceGetJobFairResult(%+v)", *p)
+}
+
+func (p *CommonServiceGetJobFairResult) GetResult() interface{} {
+	return p.Success
+}
+
 type CommonServiceGetContributorInfoArgs struct {
 	Req *GetContributorInfoRequest `thrift:"req,1" frugal:"1,default,GetContributorInfoRequest" json:"req"`
 }

--- a/kitex_gen/model/model.go
+++ b/kitex_gen/model/model.go
@@ -1778,6 +1778,79 @@ func (p *NoticeInfo) String() string {
 	return fmt.Sprintf("NoticeInfo(%+v)", *p)
 }
 
+type JobFairEvent struct {
+	Id        string `thrift:"id,1,required" frugal:"1,required,string" json:"id"`
+	Title     string `thrift:"title,2,required" frugal:"2,required,string" json:"title"`
+	Place     string `thrift:"place,3,required" frugal:"3,required,string" json:"place"`
+	Time      string `thrift:"time,4,required" frugal:"4,required,string" json:"time"`
+	StartsAt  string `thrift:"starts_at,5,required" frugal:"5,required,string" json:"starts_at"`
+	DateKey   string `thrift:"date_key,6,required" frugal:"6,required,string" json:"date_key"`
+	DetailUrl string `thrift:"detail_url,7,required" frugal:"7,required,string" json:"detail_url"`
+}
+
+func NewJobFairEvent() *JobFairEvent {
+	return &JobFairEvent{}
+}
+
+func (p *JobFairEvent) InitDefault() {
+}
+
+func (p *JobFairEvent) GetId() (v string) {
+	return p.Id
+}
+
+func (p *JobFairEvent) GetTitle() (v string) {
+	return p.Title
+}
+
+func (p *JobFairEvent) GetPlace() (v string) {
+	return p.Place
+}
+
+func (p *JobFairEvent) GetTime() (v string) {
+	return p.Time
+}
+
+func (p *JobFairEvent) GetStartsAt() (v string) {
+	return p.StartsAt
+}
+
+func (p *JobFairEvent) GetDateKey() (v string) {
+	return p.DateKey
+}
+
+func (p *JobFairEvent) GetDetailUrl() (v string) {
+	return p.DetailUrl
+}
+func (p *JobFairEvent) SetId(val string) {
+	p.Id = val
+}
+func (p *JobFairEvent) SetTitle(val string) {
+	p.Title = val
+}
+func (p *JobFairEvent) SetPlace(val string) {
+	p.Place = val
+}
+func (p *JobFairEvent) SetTime(val string) {
+	p.Time = val
+}
+func (p *JobFairEvent) SetStartsAt(val string) {
+	p.StartsAt = val
+}
+func (p *JobFairEvent) SetDateKey(val string) {
+	p.DateKey = val
+}
+func (p *JobFairEvent) SetDetailUrl(val string) {
+	p.DetailUrl = val
+}
+
+func (p *JobFairEvent) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("JobFairEvent(%+v)", *p)
+}
+
 type Contributor struct {
 	Name          string `thrift:"name,1" frugal:"1,default,string" json:"name"`
 	AvatarUrl     string `thrift:"avatar_url,2" frugal:"2,default,string" json:"avatar_url"`

--- a/kitex_gen/model/model.go
+++ b/kitex_gen/model/model.go
@@ -1783,7 +1783,7 @@ type JobFairEvent struct {
 	Title     string `thrift:"title,2,required" frugal:"2,required,string" json:"title"`
 	Place     string `thrift:"place,3,required" frugal:"3,required,string" json:"place"`
 	Time      string `thrift:"time,4,required" frugal:"4,required,string" json:"time"`
-	StartsAt  string `thrift:"starts_at,5,required" frugal:"5,required,string" json:"starts_at"`
+	StartsAt  int64  `thrift:"starts_at,5,required" frugal:"5,required,i64" json:"starts_at"`
 	DateKey   string `thrift:"date_key,6,required" frugal:"6,required,string" json:"date_key"`
 	DetailUrl string `thrift:"detail_url,7,required" frugal:"7,required,string" json:"detail_url"`
 }
@@ -1811,7 +1811,7 @@ func (p *JobFairEvent) GetTime() (v string) {
 	return p.Time
 }
 
-func (p *JobFairEvent) GetStartsAt() (v string) {
+func (p *JobFairEvent) GetStartsAt() (v int64) {
 	return p.StartsAt
 }
 
@@ -1834,7 +1834,7 @@ func (p *JobFairEvent) SetPlace(val string) {
 func (p *JobFairEvent) SetTime(val string) {
 	p.Time = val
 }
-func (p *JobFairEvent) SetStartsAt(val string) {
+func (p *JobFairEvent) SetStartsAt(val int64) {
 	p.StartsAt = val
 }
 func (p *JobFairEvent) SetDateKey(val string) {

--- a/pkg/cache/common/get_job_fair.go
+++ b/pkg/cache/common/get_job_fair.go
@@ -16,12 +16,24 @@ limitations under the License.
 
 package common
 
-import "fmt"
+import (
+	"context"
+	"fmt"
 
-func (c *CacheCommon) TermInfoKey(term string) string {
-	return fmt.Sprintf("common:term:%s", term)
-}
+	"github.com/bytedance/sonic"
 
-func (c *CacheCommon) JobFairKey(month string) string {
-	return fmt.Sprintf("common:job_fair:%s", month)
+	"github.com/west2-online/fzuhelper-server/kitex_gen/model"
+)
+
+func (c *CacheCommon) GetJobFair(ctx context.Context, key string) ([]*model.JobFairEvent, error) {
+	data, err := c.client.Get(ctx, key).Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("cache get job fair: get failed: %w", err)
+	}
+
+	var events []*model.JobFairEvent
+	if err = sonic.Unmarshal(data, &events); err != nil {
+		return nil, fmt.Errorf("cache get job fair: unmarshal failed: %w", err)
+	}
+	return events, nil
 }

--- a/pkg/cache/common/set_job_fair.go
+++ b/pkg/cache/common/set_job_fair.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2024 The west2-online Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bytedance/sonic"
+
+	"github.com/west2-online/fzuhelper-server/kitex_gen/model"
+	"github.com/west2-online/fzuhelper-server/pkg/base/environment"
+	"github.com/west2-online/fzuhelper-server/pkg/constants"
+)
+
+func (c *CacheCommon) SetJobFair(ctx context.Context, key string, events []*model.JobFairEvent) error {
+	if environment.IsTestEnvironment() {
+		return nil
+	}
+
+	data, err := sonic.Marshal(events)
+	if err != nil {
+		return fmt.Errorf("cache set job fair: marshal failed: %w", err)
+	}
+	if err = c.client.Set(ctx, key, data, constants.JobFairKeyExpire).Err(); err != nil {
+		return fmt.Errorf("cache set job fair: set failed: %w", err)
+	}
+	return nil
+}

--- a/pkg/constants/redis.go
+++ b/pkg/constants/redis.go
@@ -38,6 +38,7 @@ const (
 	ExamRoomKeyExpire           = 10 * ONE_MINUTE // [classroom] 考场信息
 	PaperFileDirKeyExpire       = 2 * ONE_DAY     // [paper] 历年卷文件目录
 	AcademicScoresExpire        = 5 * ONE_MINUTE  // [academic] 成绩信息
+	JobFairKeyExpire            = 10 * ONE_MINUTE // [common] 招聘会/宣讲会
 	VisitExpire                 = 1 * ONE_DAY     // [version]访问统计
 	LocateDateExpire            = 1 * ONE_HOUR    // [course] 定位日期
 	UserInvitationCodeKeyExpire = 1 * ONE_DAY     // [user] 邀请码

--- a/pkg/constants/singleflight.go
+++ b/pkg/constants/singleflight.go
@@ -51,6 +51,7 @@ const (
 
 	SingleflightTermPrefix       = "common:term"
 	SingleflightNoticePrefix     = "common:notice"
+	SingleflightJobFairPrefix    = "common:job_fair"
 	SingleflightPaperDirPrefix   = "paper:dir"
 	SingleflightFriendListPrefix = "user:friend_list"
 


### PR DESCRIPTION
## 主要改动

- 新增 `GET /api/v1/common/job-fair` 接口
- 将招聘会数据请求、解析和时间标准化迁移至后端
- 增加参数校验、singleflight 防重复请求及相关测试

## 测试

- `make test`
- `git diff --check`